### PR TITLE
fix exports in plain C API

### DIFF
--- a/include/simpleble_c/adapter.h
+++ b/include/simpleble_c/adapter.h
@@ -6,6 +6,14 @@
 
 #include <simpleble_c/types.h>
 
+#ifdef _WIN32
+#define SHARED_EXPORT __declspec(dllexport)
+#define CALLING_CONVENTION __cdecl
+#else
+#define SHARED_EXPORT __attribute__((visibility("default")))
+#define CALLING_CONVENTION
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -15,7 +23,7 @@ extern "C" {
  *
  * @return size_t
  */
-size_t simpleble_adapter_get_count(void);
+SHARED_EXPORT size_t CALLING_CONVENTION simpleble_adapter_get_count(void);
 
 /**
  * @brief
@@ -26,7 +34,7 @@ size_t simpleble_adapter_get_count(void);
  * @param index
  * @return simpleble_adapter_t
  */
-simpleble_adapter_t simpleble_adapter_get_handle(size_t index);
+SHARED_EXPORT simpleble_adapter_t CALLING_CONVENTION simpleble_adapter_get_handle(size_t index);
 
 /**
  * @brief Releases all memory and resources consumed by the specific
@@ -34,7 +42,7 @@ simpleble_adapter_t simpleble_adapter_get_handle(size_t index);
  *
  * @param handle
  */
-void simpleble_adapter_release_handle(simpleble_adapter_t handle);
+SHARED_EXPORT void CALLING_CONVENTION simpleble_adapter_release_handle(simpleble_adapter_t handle);
 
 /**
  * @brief Returns the identifier of a given adapter.
@@ -44,7 +52,7 @@ void simpleble_adapter_release_handle(simpleble_adapter_t handle);
  * @param handle
  * @return char*
  */
-char* simpleble_adapter_identifier(simpleble_adapter_t handle);
+SHARED_EXPORT char* CALLING_CONVENTION simpleble_adapter_identifier(simpleble_adapter_t handle);
 
 /**
  * @brief Returns the MAC address of a given adapter.
@@ -54,7 +62,7 @@ char* simpleble_adapter_identifier(simpleble_adapter_t handle);
  * @param handle
  * @return char*
  */
-char* simpleble_adapter_address(simpleble_adapter_t handle);
+SHARED_EXPORT char* CALLING_CONVENTION simpleble_adapter_address(simpleble_adapter_t handle);
 
 /**
  * @brief
@@ -62,7 +70,7 @@ char* simpleble_adapter_address(simpleble_adapter_t handle);
  * @param handle
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_adapter_scan_start(simpleble_adapter_t handle);
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_adapter_scan_start(simpleble_adapter_t handle);
 
 /**
  * @brief
@@ -70,7 +78,7 @@ simpleble_err_t simpleble_adapter_scan_start(simpleble_adapter_t handle);
  * @param handle
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_adapter_scan_stop(simpleble_adapter_t handle);
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_adapter_scan_stop(simpleble_adapter_t handle);
 
 /**
  * @brief
@@ -79,7 +87,8 @@ simpleble_err_t simpleble_adapter_scan_stop(simpleble_adapter_t handle);
  * @param active
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_adapter_scan_is_active(simpleble_adapter_t handle, bool* active);
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_adapter_scan_is_active(simpleble_adapter_t handle,
+                                                                                  bool* active);
 
 /**
  * @brief
@@ -88,7 +97,7 @@ simpleble_err_t simpleble_adapter_scan_is_active(simpleble_adapter_t handle, boo
  * @param timeout_ms
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_adapter_scan_for(simpleble_adapter_t handle, int timeout_ms);
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_adapter_scan_for(simpleble_adapter_t handle, int timeout_ms);
 
 /**
  * @brief
@@ -96,7 +105,7 @@ simpleble_err_t simpleble_adapter_scan_for(simpleble_adapter_t handle, int timeo
  * @param handle
  * @return size_t
  */
-size_t simpleble_adapter_scan_get_results_count(simpleble_adapter_t handle);
+SHARED_EXPORT size_t CALLING_CONVENTION simpleble_adapter_scan_get_results_count(simpleble_adapter_t handle);
 
 /**
  * @brief
@@ -108,7 +117,8 @@ size_t simpleble_adapter_scan_get_results_count(simpleble_adapter_t handle);
  * @param index
  * @return simpleble_peripheral_t
  */
-simpleble_peripheral_t simpleble_adapter_scan_get_results_handle(simpleble_adapter_t handle, size_t index);
+SHARED_EXPORT simpleble_peripheral_t CALLING_CONVENTION
+simpleble_adapter_scan_get_results_handle(simpleble_adapter_t handle, size_t index);
 
 /**
  * @brief
@@ -117,7 +127,7 @@ simpleble_peripheral_t simpleble_adapter_scan_get_results_handle(simpleble_adapt
  * @param callback
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_adapter_set_callback_on_scan_start(
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_adapter_set_callback_on_scan_start(
     simpleble_adapter_t handle, void (*callback)(simpleble_adapter_t adapter, void* userdata), void* userdata);
 
 /**
@@ -127,7 +137,7 @@ simpleble_err_t simpleble_adapter_set_callback_on_scan_start(
  * @param callback
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_adapter_set_callback_on_scan_stop(
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_adapter_set_callback_on_scan_stop(
     simpleble_adapter_t handle, void (*callback)(simpleble_adapter_t adapter, void* userdata), void* userdata);
 
 /**
@@ -137,7 +147,7 @@ simpleble_err_t simpleble_adapter_set_callback_on_scan_stop(
  * @param callback
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_adapter_set_callback_on_scan_updated(
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_adapter_set_callback_on_scan_updated(
     simpleble_adapter_t handle,
     void (*callback)(simpleble_adapter_t adapter, simpleble_peripheral_t peripheral, void* userdata), void* userdata);
 
@@ -148,7 +158,7 @@ simpleble_err_t simpleble_adapter_set_callback_on_scan_updated(
  * @param callback
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_adapter_set_callback_on_scan_found(
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_adapter_set_callback_on_scan_found(
     simpleble_adapter_t handle,
     void (*callback)(simpleble_adapter_t adapter, simpleble_peripheral_t peripheral, void* userdata), void* userdata);
 

--- a/include/simpleble_c/peripheral.h
+++ b/include/simpleble_c/peripheral.h
@@ -1,10 +1,18 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdbool.h>
 
 #include <simpleble_c/types.h>
+
+#ifdef _WIN32
+#define SHARED_EXPORT __declspec(dllexport)
+#define CALLING_CONVENTION __cdecl
+#else
+#define SHARED_EXPORT __attribute__((visibility("default")))
+#define CALLING_CONVENTION
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,10 +21,10 @@ extern "C" {
 /**
  * @brief Releases all memory and resources consumed by the specific
  *        instance of simpleble_peripheral_t.
- * 
+ *
  * @param handle
  */
-void simpleble_peripheral_release_handle(simpleble_peripheral_t handle);
+SHARED_EXPORT void CALLING_CONVENTION simpleble_peripheral_release_handle(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -24,7 +32,7 @@ void simpleble_peripheral_release_handle(simpleble_peripheral_t handle);
  * @param handle
  * @return char*
  */
-char* simpleble_peripheral_identifier(simpleble_peripheral_t handle);
+SHARED_EXPORT char* CALLING_CONVENTION simpleble_peripheral_identifier(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -32,7 +40,7 @@ char* simpleble_peripheral_identifier(simpleble_peripheral_t handle);
  * @param handle
  * @return char*
  */
-char* simpleble_peripheral_address(simpleble_peripheral_t handle);
+SHARED_EXPORT char* CALLING_CONVENTION simpleble_peripheral_address(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -40,7 +48,7 @@ char* simpleble_peripheral_address(simpleble_peripheral_t handle);
  * @param handle
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_connect(simpleble_peripheral_t handle);
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_peripheral_connect(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -48,7 +56,7 @@ simpleble_err_t simpleble_peripheral_connect(simpleble_peripheral_t handle);
  * @param handle
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_disconnect(simpleble_peripheral_t handle);
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_peripheral_disconnect(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -57,7 +65,8 @@ simpleble_err_t simpleble_peripheral_disconnect(simpleble_peripheral_t handle);
  * @param connected
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_is_connected(simpleble_peripheral_t handle, bool* connected);
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_peripheral_is_connected(simpleble_peripheral_t handle,
+                                                                                   bool* connected);
 
 /**
  * @brief
@@ -66,7 +75,8 @@ simpleble_err_t simpleble_peripheral_is_connected(simpleble_peripheral_t handle,
  * @param connectable
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_is_connectable(simpleble_peripheral_t handle, bool* connectable);
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_peripheral_is_connectable(simpleble_peripheral_t handle,
+                                                                                     bool* connectable);
 
 /**
  * @brief
@@ -74,7 +84,7 @@ simpleble_err_t simpleble_peripheral_is_connectable(simpleble_peripheral_t handl
  * @param handle
  * @return size_t
  */
-size_t simpleble_peripheral_services_count(simpleble_peripheral_t handle);
+SHARED_EXPORT size_t CALLING_CONVENTION simpleble_peripheral_services_count(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -84,8 +94,9 @@ size_t simpleble_peripheral_services_count(simpleble_peripheral_t handle);
  * @param services
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_services_get(simpleble_peripheral_t handle, size_t index,
-                                                  simpleble_service_t* services);
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_peripheral_services_get(simpleble_peripheral_t handle,
+                                                                                   size_t index,
+                                                                                   simpleble_service_t* services);
 
 /**
  * @brief
@@ -93,7 +104,7 @@ simpleble_err_t simpleble_peripheral_services_get(simpleble_peripheral_t handle,
  * @param handle
  * @return size_t
  */
-size_t simpleble_peripheral_manufacturer_data_count(simpleble_peripheral_t handle);
+SHARED_EXPORT size_t CALLING_CONVENTION simpleble_peripheral_manufacturer_data_count(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -103,8 +114,8 @@ size_t simpleble_peripheral_manufacturer_data_count(simpleble_peripheral_t handl
  * @param manufacturer_data
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_manufacturer_data_get(simpleble_peripheral_t handle, size_t index,
-                                                           simpleble_manufacturer_data_t* manufacturer_data);
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_peripheral_manufacturer_data_get(
+    simpleble_peripheral_t handle, size_t index, simpleble_manufacturer_data_t* manufacturer_data);
 
 /**
  * @brief
@@ -118,8 +129,10 @@ simpleble_err_t simpleble_peripheral_manufacturer_data_get(simpleble_peripheral_
  * @param data_length
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_read(simpleble_peripheral_t handle, simpleble_uuid_t service,
-                                          simpleble_uuid_t characteristic, uint8_t** data, size_t* data_length);
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_peripheral_read(simpleble_peripheral_t handle,
+                                                                           simpleble_uuid_t service,
+                                                                           simpleble_uuid_t characteristic,
+                                                                           uint8_t** data, size_t* data_length);
 
 /**
  * @brief
@@ -131,8 +144,10 @@ simpleble_err_t simpleble_peripheral_read(simpleble_peripheral_t handle, simpleb
  * @param data_length
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_write_request(simpleble_peripheral_t handle, simpleble_uuid_t service,
-                                                   simpleble_uuid_t characteristic, uint8_t* data, size_t data_length);
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_peripheral_write_request(simpleble_peripheral_t handle,
+                                                                                    simpleble_uuid_t service,
+                                                                                    simpleble_uuid_t characteristic,
+                                                                                    uint8_t* data, size_t data_length);
 
 /**
  * @brief
@@ -144,8 +159,10 @@ simpleble_err_t simpleble_peripheral_write_request(simpleble_peripheral_t handle
  * @param data_length
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_write_command(simpleble_peripheral_t handle, simpleble_uuid_t service,
-                                                   simpleble_uuid_t characteristic, uint8_t* data, size_t data_length);
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_peripheral_write_command(simpleble_peripheral_t handle,
+                                                                                    simpleble_uuid_t service,
+                                                                                    simpleble_uuid_t characteristic,
+                                                                                    uint8_t* data, size_t data_length);
 
 /**
  * @brief
@@ -156,10 +173,11 @@ simpleble_err_t simpleble_peripheral_write_command(simpleble_peripheral_t handle
  * @param callback
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_notify(simpleble_peripheral_t handle, simpleble_uuid_t service,
-                                            simpleble_uuid_t characteristic,
-                                            void (*callback)(simpleble_uuid_t service, simpleble_uuid_t characteristic,
-                                                             uint8_t* data, size_t data_length, void* userdata), void* userdata);
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION
+simpleble_peripheral_notify(simpleble_peripheral_t handle, simpleble_uuid_t service, simpleble_uuid_t characteristic,
+                            void (*callback)(simpleble_uuid_t service, simpleble_uuid_t characteristic, uint8_t* data,
+                                             size_t data_length, void* userdata),
+                            void* userdata);
 
 /**
  * @brief
@@ -170,9 +188,11 @@ simpleble_err_t simpleble_peripheral_notify(simpleble_peripheral_t handle, simpl
  * @param callback
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_indicate(
-    simpleble_peripheral_t handle, simpleble_uuid_t service, simpleble_uuid_t characteristic,
-    void (*callback)(simpleble_uuid_t service, simpleble_uuid_t characteristic, uint8_t* data, size_t data_length, void* userdata), void* userdata);
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION
+simpleble_peripheral_indicate(simpleble_peripheral_t handle, simpleble_uuid_t service, simpleble_uuid_t characteristic,
+                              void (*callback)(simpleble_uuid_t service, simpleble_uuid_t characteristic, uint8_t* data,
+                                               size_t data_length, void* userdata),
+                              void* userdata);
 
 /**
  * @brief
@@ -182,8 +202,9 @@ simpleble_err_t simpleble_peripheral_indicate(
  * @param characteristic
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_unsubscribe(simpleble_peripheral_t handle, simpleble_uuid_t service,
-                                                 simpleble_uuid_t characteristic);
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_peripheral_unsubscribe(simpleble_peripheral_t handle,
+                                                                                  simpleble_uuid_t service,
+                                                                                  simpleble_uuid_t characteristic);
 
 /**
  * @brief
@@ -192,8 +213,8 @@ simpleble_err_t simpleble_peripheral_unsubscribe(simpleble_peripheral_t handle, 
  * @param callback
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_set_callback_on_connected(simpleble_peripheral_t handle,
-                                                               void (*callback)(simpleble_peripheral_t peripheral, void* userdata), void* userdata);
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_peripheral_set_callback_on_connected(
+    simpleble_peripheral_t handle, void (*callback)(simpleble_peripheral_t peripheral, void* userdata), void* userdata);
 
 /**
  * @brief
@@ -202,8 +223,8 @@ simpleble_err_t simpleble_peripheral_set_callback_on_connected(simpleble_periphe
  * @param callback
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_set_callback_on_disconnected(simpleble_peripheral_t handle,
-                                                                  void (*callback)(simpleble_peripheral_t peripheral, void* userdata), void* userdata);
+SHARED_EXPORT simpleble_err_t CALLING_CONVENTION simpleble_peripheral_set_callback_on_disconnected(
+    simpleble_peripheral_t handle, void (*callback)(simpleble_peripheral_t peripheral, void* userdata), void* userdata);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Signed-off-by: Andrey Parfenov <a1994ndrey@gmail.com>

Currently, plain C methods are not exported(it's very simple to check on Windows), this patch fixes it.  Command to test it is:
```
"D:\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.16.27023\bin\HostX64\x64\dumpbin.exe"/exports D:\workspace\brainflow\python-package\brainflow\lib\simpleble-c.dll
```
Run it with and wo this patch to see the difference(you need to change paths), you can do the same via UI using this tool: https://www.nirsoft.net/utils/dll_export_viewer.html