### PR TITLE
Added auto export feature for Windows DLLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,10 +159,14 @@ set_property(TARGET simpleble-static PROPERTY CXX_STANDARD 17)
 set_property(TARGET simpleble PROPERTY CXX_STANDARD 17)
 set_property(TARGET simpleble-c-static PROPERTY CXX_STANDARD 17)
 set_property(TARGET simpleble-c PROPERTY CXX_STANDARD 17)
+
 set_property(TARGET simpleble-static PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET simpleble PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET simpleble-c-static PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET simpleble-c PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+set_property(TARGET simpleble PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
+set_property(TARGET simpleble-c PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 target_include_directories(simpleble-static PRIVATE ${SIMPLE_BLE_ALL_INCLUDE_DIRS})
 target_include_directories(simpleble PRIVATE ${SIMPLE_BLE_ALL_INCLUDE_DIRS})

--- a/include/simpleble_c/adapter.h
+++ b/include/simpleble_c/adapter.h
@@ -6,12 +6,6 @@
 
 #include <simpleble_c/types.h>
 
-#ifdef _WIN32
-#define EXPORT_SYMBOL __declspec(dllexport)
-#else
-#define EXPORT_SYMBOL
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -21,7 +15,7 @@ extern "C" {
  *
  * @return size_t
  */
-EXPORT_SYMBOL size_t simpleble_adapter_get_count(void);
+size_t simpleble_adapter_get_count(void);
 
 /**
  * @brief
@@ -32,7 +26,7 @@ EXPORT_SYMBOL size_t simpleble_adapter_get_count(void);
  * @param index
  * @return simpleble_adapter_t
  */
-EXPORT_SYMBOL simpleble_adapter_t simpleble_adapter_get_handle(size_t index);
+simpleble_adapter_t simpleble_adapter_get_handle(size_t index);
 
 /**
  * @brief Releases all memory and resources consumed by the specific
@@ -40,7 +34,7 @@ EXPORT_SYMBOL simpleble_adapter_t simpleble_adapter_get_handle(size_t index);
  *
  * @param handle
  */
-EXPORT_SYMBOL void simpleble_adapter_release_handle(simpleble_adapter_t handle);
+void simpleble_adapter_release_handle(simpleble_adapter_t handle);
 
 /**
  * @brief Returns the identifier of a given adapter.
@@ -50,7 +44,7 @@ EXPORT_SYMBOL void simpleble_adapter_release_handle(simpleble_adapter_t handle);
  * @param handle
  * @return char*
  */
-EXPORT_SYMBOL char* simpleble_adapter_identifier(simpleble_adapter_t handle);
+char* simpleble_adapter_identifier(simpleble_adapter_t handle);
 
 /**
  * @brief Returns the MAC address of a given adapter.
@@ -60,7 +54,7 @@ EXPORT_SYMBOL char* simpleble_adapter_identifier(simpleble_adapter_t handle);
  * @param handle
  * @return char*
  */
-EXPORT_SYMBOL char* simpleble_adapter_address(simpleble_adapter_t handle);
+char* simpleble_adapter_address(simpleble_adapter_t handle);
 
 /**
  * @brief
@@ -68,7 +62,7 @@ EXPORT_SYMBOL char* simpleble_adapter_address(simpleble_adapter_t handle);
  * @param handle
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_adapter_scan_start(simpleble_adapter_t handle);
+simpleble_err_t simpleble_adapter_scan_start(simpleble_adapter_t handle);
 
 /**
  * @brief
@@ -76,7 +70,7 @@ EXPORT_SYMBOL simpleble_err_t simpleble_adapter_scan_start(simpleble_adapter_t h
  * @param handle
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_adapter_scan_stop(simpleble_adapter_t handle);
+simpleble_err_t simpleble_adapter_scan_stop(simpleble_adapter_t handle);
 
 /**
  * @brief
@@ -85,7 +79,7 @@ EXPORT_SYMBOL simpleble_err_t simpleble_adapter_scan_stop(simpleble_adapter_t ha
  * @param active
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_adapter_scan_is_active(simpleble_adapter_t handle, bool* active);
+simpleble_err_t simpleble_adapter_scan_is_active(simpleble_adapter_t handle, bool* active);
 
 /**
  * @brief
@@ -94,7 +88,7 @@ EXPORT_SYMBOL simpleble_err_t simpleble_adapter_scan_is_active(simpleble_adapter
  * @param timeout_ms
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_adapter_scan_for(simpleble_adapter_t handle, int timeout_ms);
+simpleble_err_t simpleble_adapter_scan_for(simpleble_adapter_t handle, int timeout_ms);
 
 /**
  * @brief
@@ -102,7 +96,7 @@ EXPORT_SYMBOL simpleble_err_t simpleble_adapter_scan_for(simpleble_adapter_t han
  * @param handle
  * @return size_t
  */
-EXPORT_SYMBOL size_t simpleble_adapter_scan_get_results_count(simpleble_adapter_t handle);
+size_t simpleble_adapter_scan_get_results_count(simpleble_adapter_t handle);
 
 /**
  * @brief
@@ -114,7 +108,7 @@ EXPORT_SYMBOL size_t simpleble_adapter_scan_get_results_count(simpleble_adapter_
  * @param index
  * @return simpleble_peripheral_t
  */
-EXPORT_SYMBOL simpleble_peripheral_t simpleble_adapter_scan_get_results_handle(simpleble_adapter_t handle, size_t index);
+simpleble_peripheral_t simpleble_adapter_scan_get_results_handle(simpleble_adapter_t handle, size_t index);
 
 /**
  * @brief
@@ -123,7 +117,7 @@ EXPORT_SYMBOL simpleble_peripheral_t simpleble_adapter_scan_get_results_handle(s
  * @param callback
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_adapter_set_callback_on_scan_start(
+simpleble_err_t simpleble_adapter_set_callback_on_scan_start(
     simpleble_adapter_t handle, void (*callback)(simpleble_adapter_t adapter, void* userdata), void* userdata);
 
 /**
@@ -133,7 +127,7 @@ EXPORT_SYMBOL simpleble_err_t simpleble_adapter_set_callback_on_scan_start(
  * @param callback
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_adapter_set_callback_on_scan_stop(
+simpleble_err_t simpleble_adapter_set_callback_on_scan_stop(
     simpleble_adapter_t handle, void (*callback)(simpleble_adapter_t adapter, void* userdata), void* userdata);
 
 /**
@@ -143,7 +137,7 @@ EXPORT_SYMBOL simpleble_err_t simpleble_adapter_set_callback_on_scan_stop(
  * @param callback
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_adapter_set_callback_on_scan_updated(
+simpleble_err_t simpleble_adapter_set_callback_on_scan_updated(
     simpleble_adapter_t handle,
     void (*callback)(simpleble_adapter_t adapter, simpleble_peripheral_t peripheral, void* userdata), void* userdata);
 
@@ -154,7 +148,7 @@ EXPORT_SYMBOL simpleble_err_t simpleble_adapter_set_callback_on_scan_updated(
  * @param callback
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_adapter_set_callback_on_scan_found(
+simpleble_err_t simpleble_adapter_set_callback_on_scan_found(
     simpleble_adapter_t handle,
     void (*callback)(simpleble_adapter_t adapter, simpleble_peripheral_t peripheral, void* userdata), void* userdata);
 

--- a/include/simpleble_c/peripheral.h
+++ b/include/simpleble_c/peripheral.h
@@ -6,12 +6,6 @@
 
 #include <simpleble_c/types.h>
 
-#ifdef _WIN32
-#define EXPORT_SYMBOL __declspec(dllexport)
-#else
-#define EXPORT_SYMBOL
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -22,7 +16,7 @@ extern "C" {
  *
  * @param handle
  */
-EXPORT_SYMBOL void simpleble_peripheral_release_handle(simpleble_peripheral_t handle);
+void simpleble_peripheral_release_handle(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -30,7 +24,7 @@ EXPORT_SYMBOL void simpleble_peripheral_release_handle(simpleble_peripheral_t ha
  * @param handle
  * @return char*
  */
-EXPORT_SYMBOL char* simpleble_peripheral_identifier(simpleble_peripheral_t handle);
+char* simpleble_peripheral_identifier(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -38,7 +32,7 @@ EXPORT_SYMBOL char* simpleble_peripheral_identifier(simpleble_peripheral_t handl
  * @param handle
  * @return char*
  */
-EXPORT_SYMBOL char* simpleble_peripheral_address(simpleble_peripheral_t handle);
+char* simpleble_peripheral_address(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -46,7 +40,7 @@ EXPORT_SYMBOL char* simpleble_peripheral_address(simpleble_peripheral_t handle);
  * @param handle
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_connect(simpleble_peripheral_t handle);
+simpleble_err_t simpleble_peripheral_connect(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -54,7 +48,7 @@ EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_connect(simpleble_peripheral_
  * @param handle
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_disconnect(simpleble_peripheral_t handle);
+simpleble_err_t simpleble_peripheral_disconnect(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -63,7 +57,7 @@ EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_disconnect(simpleble_peripher
  * @param connected
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_is_connected(simpleble_peripheral_t handle, bool* connected);
+simpleble_err_t simpleble_peripheral_is_connected(simpleble_peripheral_t handle, bool* connected);
 
 /**
  * @brief
@@ -72,7 +66,7 @@ EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_is_connected(simpleble_periph
  * @param connectable
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_is_connectable(simpleble_peripheral_t handle, bool* connectable);
+simpleble_err_t simpleble_peripheral_is_connectable(simpleble_peripheral_t handle, bool* connectable);
 
 /**
  * @brief
@@ -80,7 +74,7 @@ EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_is_connectable(simpleble_peri
  * @param handle
  * @return size_t
  */
-EXPORT_SYMBOL size_t simpleble_peripheral_services_count(simpleble_peripheral_t handle);
+size_t simpleble_peripheral_services_count(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -90,8 +84,8 @@ EXPORT_SYMBOL size_t simpleble_peripheral_services_count(simpleble_peripheral_t 
  * @param services
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_services_get(simpleble_peripheral_t handle, size_t index,
-                                                                simpleble_service_t* services);
+simpleble_err_t simpleble_peripheral_services_get(simpleble_peripheral_t handle, size_t index,
+                                                  simpleble_service_t* services);
 
 /**
  * @brief
@@ -99,7 +93,7 @@ EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_services_get(simpleble_periph
  * @param handle
  * @return size_t
  */
-EXPORT_SYMBOL size_t simpleble_peripheral_manufacturer_data_count(simpleble_peripheral_t handle);
+size_t simpleble_peripheral_manufacturer_data_count(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -109,8 +103,8 @@ EXPORT_SYMBOL size_t simpleble_peripheral_manufacturer_data_count(simpleble_peri
  * @param manufacturer_data
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_manufacturer_data_get(
-    simpleble_peripheral_t handle, size_t index, simpleble_manufacturer_data_t* manufacturer_data);
+simpleble_err_t simpleble_peripheral_manufacturer_data_get(simpleble_peripheral_t handle, size_t index,
+                                                           simpleble_manufacturer_data_t* manufacturer_data);
 
 /**
  * @brief
@@ -124,9 +118,8 @@ EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_manufacturer_data_get(
  * @param data_length
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_read(simpleble_peripheral_t handle, simpleble_uuid_t service,
-                                                        simpleble_uuid_t characteristic, uint8_t** data,
-                                                        size_t* data_length);
+simpleble_err_t simpleble_peripheral_read(simpleble_peripheral_t handle, simpleble_uuid_t service,
+                                          simpleble_uuid_t characteristic, uint8_t** data, size_t* data_length);
 
 /**
  * @brief
@@ -138,10 +131,8 @@ EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_read(simpleble_peripheral_t h
  * @param data_length
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_write_request(simpleble_peripheral_t handle,
-                                                                 simpleble_uuid_t service,
-                                                                 simpleble_uuid_t characteristic, uint8_t* data,
-                                                                 size_t data_length);
+simpleble_err_t simpleble_peripheral_write_request(simpleble_peripheral_t handle, simpleble_uuid_t service,
+                                                   simpleble_uuid_t characteristic, uint8_t* data, size_t data_length);
 
 /**
  * @brief
@@ -153,10 +144,8 @@ EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_write_request(simpleble_perip
  * @param data_length
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_write_command(simpleble_peripheral_t handle,
-                                                                 simpleble_uuid_t service,
-                                                                 simpleble_uuid_t characteristic, uint8_t* data,
-                                                                 size_t data_length);
+simpleble_err_t simpleble_peripheral_write_command(simpleble_peripheral_t handle, simpleble_uuid_t service,
+                                                   simpleble_uuid_t characteristic, uint8_t* data, size_t data_length);
 
 /**
  * @brief
@@ -167,11 +156,11 @@ EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_write_command(simpleble_perip
  * @param callback
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t
-simpleble_peripheral_notify(simpleble_peripheral_t handle, simpleble_uuid_t service, simpleble_uuid_t characteristic,
-                            void (*callback)(simpleble_uuid_t service, simpleble_uuid_t characteristic, uint8_t* data,
-                                             size_t data_length, void* userdata),
-                            void* userdata);
+simpleble_err_t simpleble_peripheral_notify(simpleble_peripheral_t handle, simpleble_uuid_t service,
+                                            simpleble_uuid_t characteristic,
+                                            void (*callback)(simpleble_uuid_t service, simpleble_uuid_t characteristic,
+                                                             uint8_t* data, size_t data_length, void* userdata),
+                                            void* userdata);
 
 /**
  * @brief
@@ -182,11 +171,12 @@ simpleble_peripheral_notify(simpleble_peripheral_t handle, simpleble_uuid_t serv
  * @param callback
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t
-simpleble_peripheral_indicate(simpleble_peripheral_t handle, simpleble_uuid_t service, simpleble_uuid_t characteristic,
-                              void (*callback)(simpleble_uuid_t service, simpleble_uuid_t characteristic, uint8_t* data,
-                                               size_t data_length, void* userdata),
-                              void* userdata);
+simpleble_err_t simpleble_peripheral_indicate(simpleble_peripheral_t handle, simpleble_uuid_t service,
+                                              simpleble_uuid_t characteristic,
+                                              void (*callback)(simpleble_uuid_t service,
+                                                               simpleble_uuid_t characteristic, uint8_t* data,
+                                                               size_t data_length, void* userdata),
+                                              void* userdata);
 
 /**
  * @brief
@@ -196,8 +186,8 @@ simpleble_peripheral_indicate(simpleble_peripheral_t handle, simpleble_uuid_t se
  * @param characteristic
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_unsubscribe(simpleble_peripheral_t handle, simpleble_uuid_t service,
-                                                               simpleble_uuid_t characteristic);
+simpleble_err_t simpleble_peripheral_unsubscribe(simpleble_peripheral_t handle, simpleble_uuid_t service,
+                                                 simpleble_uuid_t characteristic);
 
 /**
  * @brief
@@ -206,7 +196,7 @@ EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_unsubscribe(simpleble_periphe
  * @param callback
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_set_callback_on_connected(
+simpleble_err_t simpleble_peripheral_set_callback_on_connected(
     simpleble_peripheral_t handle, void (*callback)(simpleble_peripheral_t peripheral, void* userdata), void* userdata);
 
 /**
@@ -216,7 +206,7 @@ EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_set_callback_on_connected(
  * @param callback
  * @return simpleble_err_t
  */
-EXPORT_SYMBOL simpleble_err_t simpleble_peripheral_set_callback_on_disconnected(
+simpleble_err_t simpleble_peripheral_set_callback_on_disconnected(
     simpleble_peripheral_t handle, void (*callback)(simpleble_peripheral_t peripheral, void* userdata), void* userdata);
 
 #ifdef __cplusplus

--- a/include/simpleble_c/simpleble.h
+++ b/include/simpleble_c/simpleble.h
@@ -3,12 +3,6 @@
 #include <simpleble_c/adapter.h>
 #include <simpleble_c/peripheral.h>
 
-#ifdef _WIN32
-#define EXPORT_SYMBOL __declspec(dllexport)
-#else
-#define EXPORT_SYMBOL
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,7 +13,7 @@ extern "C" {
  *
  * @param handle
  */
-EXPORT_SYMBOL void simpleble_free(void* handle);
+void simpleble_free(void* handle);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
@Andrey1994 I added a setting to CMake that should automatically export all symbols from the shared libraries. Can you tell me if this works for you?