### PR TITLE
Allow subscribing to Bluetooth state changes

### DIFF
--- a/include/simpleble/Adapter.h
+++ b/include/simpleble/Adapter.h
@@ -31,6 +31,7 @@ class Adapter {
     void set_callback_on_scan_stop(std::function<void()> on_scan_stop);
     void set_callback_on_scan_updated(std::function<void(Peripheral)> on_scan_updated);
     void set_callback_on_scan_found(std::function<void(Peripheral)> on_scan_found);
+    void set_callback_on_state_changed(std::function<void(BluetoothState)> on_state_changed);
 
     static std::vector<Adapter> get_adapters();
 

--- a/include/simpleble/Types.h
+++ b/include/simpleble/Types.h
@@ -21,4 +21,13 @@ typedef struct {
     std::vector<BluetoothUUID> characteristics;
 } BluetoothService;
 
+typedef enum {
+    Unknown = 0,
+    Resetting = 1,
+    Unsupported = 2,
+    Unauthorized = 3,
+    PoweredOff = 4,
+    PoweredOn = 5,
+} BluetoothState;
+
 }  // namespace SimpleBLE

--- a/src/Adapter.cpp
+++ b/src/Adapter.cpp
@@ -54,3 +54,7 @@ void Adapter::set_callback_on_scan_updated(std::function<void(Peripheral)> on_sc
 void Adapter::set_callback_on_scan_found(std::function<void(Peripheral)> on_scan_found) {
     internal_->set_callback_on_scan_found(on_scan_found);
 }
+
+void Adapter::set_callback_on_state_changed(std::function<void(BluetoothState)> on_state_changed) {
+    internal_->set_callback_on_state_changed(on_state_changed);
+}

--- a/src/macos/AdapterBase.h
+++ b/src/macos/AdapterBase.h
@@ -35,6 +35,7 @@ class AdapterBase {
     void set_callback_on_scan_stop(std::function<void()> on_scan_stop);
     void set_callback_on_scan_updated(std::function<void(Peripheral)> on_scan_updated);
     void set_callback_on_scan_found(std::function<void(Peripheral)> on_scan_found);
+    void set_callback_on_state_changed(std::function<void(BluetoothState)> on_state_changed);
 
     static std::vector<std::shared_ptr<AdapterBase> > get_adapters();
 
@@ -42,6 +43,7 @@ class AdapterBase {
                                           advertising_data_t advertising_data);
     void delegate_did_connect_peripheral(void* opaque_peripheral);
     void delegate_did_disconnect_peripheral(void* opaque_peripheral);
+    void delegate_did_change_state(BluetoothState state);
 
   protected:
     /**
@@ -53,6 +55,7 @@ class AdapterBase {
     std::function<void()> callback_on_scan_stop_;
     std::function<void(Peripheral)> callback_on_scan_updated_;
     std::function<void(Peripheral)> callback_on_scan_found_;
+    std::function<void(BluetoothState)> callback_on_state_changed_;
 
     /**
      * Holds a map of objective-c peripheral objects to their corresponding C++ objects.

--- a/src/macos/AdapterBase.mm
+++ b/src/macos/AdapterBase.mm
@@ -77,6 +77,8 @@ void AdapterBase::set_callback_on_scan_updated(std::function<void(Peripheral)> o
 }
 void AdapterBase::set_callback_on_scan_found(std::function<void(Peripheral)> on_scan_found) { callback_on_scan_found_ = on_scan_found; }
 
+void AdapterBase::set_callback_on_state_changed(std::function<void(BluetoothState)> on_state_changed) { callback_on_state_changed_ = on_state_changed; }
+
 // Delegate methods passed for AdapterBaseMacOS
 
 void AdapterBase::delegate_did_discover_peripheral(void* opaque_peripheral, void* opaque_adapter, advertising_data_t advertising_data) {
@@ -123,4 +125,10 @@ void AdapterBase::delegate_did_disconnect_peripheral(void* opaque_peripheral) {
     // Load the existing PeripheralBase object
     std::shared_ptr<PeripheralBase> base_peripheral = this->peripherals_.at(opaque_peripheral);
     base_peripheral->delegate_did_disconnect();
+}
+
+void AdapterBase::delegate_did_change_state(BluetoothState state) {
+    if (this->callback_on_state_changed_) {
+        this->callback_on_state_changed_(state);
+    }
 }

--- a/src/macos/AdapterBaseMacOS.mm
+++ b/src/macos/AdapterBaseMacOS.mm
@@ -69,28 +69,38 @@
 #pragma mark - CBCentralManagerDelegate
 
 - (void)centralManagerDidUpdateState:(CBCentralManager*)central {
+    SimpleBLE::BluetoothState bts = SimpleBLE::Unknown;
+
     switch (central.state) {
         case CBManagerStateUnknown:
+            bts = SimpleBLE::BluetoothState::Unknown;
             // NSLog(@"CBManagerStateUnknown!\n");
             break;
         case CBManagerStateResetting:
+            bts = SimpleBLE::BluetoothState::Resetting;
             // NSLog(@"CBManagerStateResetting!\n");
             break;
         case CBManagerStateUnsupported:
+            bts = SimpleBLE::BluetoothState::Unsupported;
             // NSLog(@"CBManagerStateUnsupported!\n");
             break;
         case CBManagerStateUnauthorized:
+            bts = SimpleBLE::BluetoothState::Unauthorized;
             // NSLog(@"CBManagerStateUnauthorized!\n");
             break;
         case CBManagerStatePoweredOff:
+            bts = SimpleBLE::BluetoothState::PoweredOff;
             // NSLog(@"CBManagerStatePoweredOff!\n");
             // NOTE: Notify the user that the Bluetooth adapter is turned off.
             break;
         case CBManagerStatePoweredOn:
+            bts = SimpleBLE::BluetoothState::PoweredOn;
             // NOTE: This state is required to be able to operate CoreBluetooth.
             // NSLog(@"CBManagerStatePoweredOn!\n");
             break;
     }
+
+    _adapter->delegate_did_change_state(bts);
 }
 
 - (void)centralManager:(CBCentralManager*)central


### PR DESCRIPTION
I think it would be good to have a way to listen to changes in the bluetooth adapter state (Power on/off, Authorized, etc.). Since there is already a delegate for centralManagerDidUpdateState, adding the callback is quite simple. 

I'm not sure whether Windows or Linux provide a similar functionality, but this PR should contain the necessary changes for MacOS. 