### PR TITLE
Read the characteristic value from the peer instead of the cache (Linux)

### DIFF
--- a/src/linux/PeripheralBase.cpp
+++ b/src/linux/PeripheralBase.cpp
@@ -91,7 +91,7 @@ std::map<uint16_t, ByteArray> PeripheralBase::manufacturer_data() {
 
 ByteArray PeripheralBase::read(BluetoothUUID service, BluetoothUUID characteristic) {
     // TODO: Check if the characteristic is readable.
-    return _get_characteristic(service, characteristic)->value();
+    return _get_characteristic(service, characteristic)->read();
 }
 
 void PeripheralBase::write_request(BluetoothUUID service, BluetoothUUID characteristic, ByteArray data) {


### PR DESCRIPTION
On Linux, when reading various Characteristic's values, the value was either empty or out of date. Fixed this by using the appropriate function from SimpleBluez.