### PR TITLE
Emulate unavailable battery service if Bluez Battery1 interface is found

### DIFF
--- a/src/linux/PeripheralBase.cpp
+++ b/src/linux/PeripheralBase.cpp
@@ -1,8 +1,8 @@
 #include "PeripheralBase.h"
 
-#include <algorithm>
 #include <simpleble/Exceptions.h>
 #include <simplebluez/Exceptions.h>
+#include <algorithm>
 
 #include "Bluez.h"
 
@@ -112,8 +112,9 @@ ByteArray PeripheralBase::read(BluetoothUUID service, BluetoothUUID characterist
         if (device_->has_battery_interface()) {
             char percentage = device_->read_battery_percentage();
             return ByteArray(&percentage, 1);
+        } else {
+            throw;
         }
-        else throw;
     }
 }
 
@@ -133,7 +134,8 @@ void PeripheralBase::notify(BluetoothUUID service, BluetoothUUID characteristic,
     // TODO: Check if the property can be notified.
     try {
         auto characteristic_object = _get_characteristic(service, characteristic);
-        characteristic_object->set_on_value_changed([callback](SimpleBluez::ByteArray new_value) { callback(new_value); });
+        characteristic_object->set_on_value_changed(
+            [callback](SimpleBluez::ByteArray new_value) { callback(new_value); });
         characteristic_object->start_notify();
     } catch (Exception::ServiceNotFound& e) {
         if (device_->has_battery_interface()) {
@@ -141,8 +143,9 @@ void PeripheralBase::notify(BluetoothUUID service, BluetoothUUID characteristic,
                 char byte_value = new_value;
                 callback(ByteArray(&byte_value, 1));
             });
+        } else {
+            throw;
         }
-        else throw;
     }
 }
 
@@ -166,8 +169,9 @@ void PeripheralBase::unsubscribe(BluetoothUUID service, BluetoothUUID characteri
     } catch (Exception::ServiceNotFound& e) {
         if (device_->has_battery_interface()) {
             device_->clear_on_battery_percentage_changed();
+        } else {
+            throw;
         }
-        else throw;
     }
 }
 

--- a/src/linux/PeripheralBase.cpp
+++ b/src/linux/PeripheralBase.cpp
@@ -1,9 +1,13 @@
 #include "PeripheralBase.h"
 
+#include <algorithm>
 #include <simpleble/Exceptions.h>
 #include <simplebluez/Exceptions.h>
 
 #include "Bluez.h"
+
+const SimpleBLE::BluetoothUUID BATTERY_SERVICE_UUID = "0000180f-0000-1000-8000-00805f9b34fb";
+const SimpleBLE::BluetoothUUID BATTERY_CHARACTERISTIC_UUID = "00002a19-0000-1000-8000-00805f9b34fb";
 
 using namespace SimpleBLE;
 using namespace std::chrono_literals;
@@ -77,6 +81,17 @@ std::vector<BluetoothService> PeripheralBase::services() {
         service_list.push_back(service);
     }
 
+    auto is_battery_service = [](const BluetoothService& service) { return service.uuid == BATTERY_SERVICE_UUID; };
+    if (std::find_if(service_list.begin(), service_list.end(), is_battery_service) == service_list.end()) {
+        // no battery service found -> emulate service via Battery1 interface if available
+        if (device_->has_battery_interface()) {
+            BluetoothService service;
+            service.uuid = BATTERY_SERVICE_UUID;
+            service.characteristics.push_back(BATTERY_CHARACTERISTIC_UUID);
+            service_list.push_back(service);
+        }
+    }
+
     return service_list;
 }
 
@@ -91,7 +106,15 @@ std::map<uint16_t, ByteArray> PeripheralBase::manufacturer_data() {
 
 ByteArray PeripheralBase::read(BluetoothUUID service, BluetoothUUID characteristic) {
     // TODO: Check if the characteristic is readable.
-    return _get_characteristic(service, characteristic)->read();
+    try {
+        return _get_characteristic(service, characteristic)->read();
+    } catch (Exception::ServiceNotFound& e) {
+        if (device_->has_battery_interface()) {
+            char percentage = device_->read_battery_percentage();
+            return ByteArray(&percentage, 1);
+        }
+        else throw;
+    }
 }
 
 void PeripheralBase::write_request(BluetoothUUID service, BluetoothUUID characteristic, ByteArray data) {
@@ -108,9 +131,19 @@ void PeripheralBase::notify(BluetoothUUID service, BluetoothUUID characteristic,
                             std::function<void(ByteArray payload)> callback) {
     // TODO: What to do if the characteristic is already being notified?
     // TODO: Check if the property can be notified.
-    auto characteristic_object = _get_characteristic(service, characteristic);
-    characteristic_object->set_on_value_changed([callback](SimpleBluez::ByteArray new_value) { callback(new_value); });
-    characteristic_object->start_notify();
+    try {
+        auto characteristic_object = _get_characteristic(service, characteristic);
+        characteristic_object->set_on_value_changed([callback](SimpleBluez::ByteArray new_value) { callback(new_value); });
+        characteristic_object->start_notify();
+    } catch (Exception::ServiceNotFound& e) {
+        if (device_->has_battery_interface()) {
+            device_->set_on_battery_percentage_changed([callback](uint8_t new_value) {
+                char byte_value = new_value;
+                callback(ByteArray(&byte_value, 1));
+            });
+        }
+        else throw;
+    }
 }
 
 void PeripheralBase::indicate(BluetoothUUID service, BluetoothUUID characteristic,
@@ -120,14 +153,21 @@ void PeripheralBase::indicate(BluetoothUUID service, BluetoothUUID characteristi
 
 void PeripheralBase::unsubscribe(BluetoothUUID service, BluetoothUUID characteristic) {
     // TODO: What to do if the characteristic is not being notified?
-    auto characteristic_object = _get_characteristic(service, characteristic);
-    characteristic_object->stop_notify();
+    try {
+        auto characteristic_object = _get_characteristic(service, characteristic);
+        characteristic_object->stop_notify();
 
-    // Wait for the characteristic to stop notifying.
-    // TODO: Upgrade SimpleDBus to provide a way to wait for this signal.
-    auto timeout = std::chrono::system_clock::now() + 5s;
-    while (characteristic_object->notifying() && std::chrono::system_clock::now() < timeout) {
-        std::this_thread::sleep_for(50ms);
+        // Wait for the characteristic to stop notifying.
+        // TODO: Upgrade SimpleDBus to provide a way to wait for this signal.
+        auto timeout = std::chrono::system_clock::now() + 5s;
+        while (characteristic_object->notifying() && std::chrono::system_clock::now() < timeout) {
+            std::this_thread::sleep_for(50ms);
+        }
+    } catch (Exception::ServiceNotFound& e) {
+        if (device_->has_battery_interface()) {
+            device_->clear_on_battery_percentage_changed();
+        }
+        else throw;
     }
 }
 


### PR DESCRIPTION
On Linux, the battery service (UUID 0x180f) is filtered out if the Bluez battery plugin is loaded (Bluez version >= 5.48). This seems to be standard behaviour on Ubuntu 20.04 and probably other distributions as well.

This PR emulates the battery service by using the Battery1 interface of Bluez. Requires related [PR in SimpleBLE](https://github.com/OpenBluetoothToolbox/SimpleBluez/pull/3).

Functionality of this workaround was tested on Ubuntu 20.04, Bluez version 5.53, with activated and deactivated battery plugin (`example_read` and `example_notify`).

Notable differences in behaviour of the emulated battery service:

- Only the battery percentage characteristic is emulated (UUID 0x2a19)
- On percentage characteristic read, the current value provided by the Battery1 interface is returned. There is no actual characteristic read happening via BLE
- Notifications only occur if `property_changed` is called. This only happens when the value actually changes, not each time a notification arrives over BLE. The callback is thus called (a lot) less often then for a "proper" notification

The battery plugin [can be disabled](https://github.com/hbldh/bleak/issues/393) to use the actual battery service and characteristic, see. However, this might not always be an option, so I think it is a good idea to include this workaround.