### PR TITLE
build: overhaul CMake

### DIFF
--- a/cmake/prelude.cmake
+++ b/cmake/prelude.cmake
@@ -2,6 +2,10 @@
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/find)
 
+include(GNUInstallDirs)
+include(InstallRequiredSystemLibraries)
+include(CMakePackageConfigHelpers)
+
 # Detect if the project is being build within a project or standalone.
 if(PROJECT_IS_TOP_LEVEL)
     # Configure the build path
@@ -46,6 +50,35 @@ macro(apply_build_options
         target_link_options(${TARGET} PUBLIC ${OPTION})
     endforeach()
 
+endmacro()
+
+macro(install_target tgt)
+    set(bools)
+    set(single EXPORT NAMESPACE VERSION CMAKE_INPUT_FILE CMAKE_OUTPUT_FILE)
+    set(multi)
+
+    cmake_parse_arguments(_SBLE "${bools}" "${single}" "${multi}" ${ARGN})
+
+    configure_package_config_file(${_SBLE_CMAKE_INPUT_FILE} ${_SBLE_CMAKE_OUTPUT_FILE}
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${_SBLE_EXPORT})
+    write_basic_package_version_file("${_SBLE_EXPORT}-config-version.cmake"
+        VERSION ${_SBLE_VERSION}
+        COMPATIBILITY SameMajorVersion)
+
+    install(TARGETS ${tgt} fmt-header-only
+        EXPORT ${_SBLE_EXPORT}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+    install(EXPORT ${_SBLE_EXPORT}
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${_SBLE_EXPORT}
+        NAMESPACE ${_SBLE_NAMESPACE}
+        FILE "${_SBLE_EXPORT}-targets.cmake"
+    )
+    install(FILES ${_SBLE_CMAKE_OUTPUT_FILE}
+        ${CMAKE_CURRENT_BINARY_DIR}/${_SBLE_EXPORT}-config-version.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${_SBLE_EXPORT})
 endmacro()
 
 macro(append_sanitize_options MODIFIER)

--- a/simpleble/CMakeLists.txt
+++ b/simpleble/CMakeLists.txt
@@ -15,13 +15,18 @@ project(
 include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/prelude.cmake)
 
 option(LIBFMT_VENDORIZE "Enable vendorized libfmt" ON)
+option(BUILD_SIMPLEBLE_SHARED "Build as a shared library" OFF)
+option(BUILD_SIMPLEBLE_C_SHARED "Build SimpleBLE-C as a shared library" OFF)
+
 find_package(fmt REQUIRED)
 
-set(SIMPLEBLE_PRIVATE_INCLUDES
-    ${CMAKE_CURRENT_SOURCE_DIR}/src
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/builders
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/external)
+if(BUILD_SIMPLEBLE_SHARED)
+    set(_LIBTYPE "SHARED")
+endif()
+
+if(BUILD_SIMPLEBLE_C_SHARED)
+    set(_CLIBTYPE "SHARED")
+endif()
 
 set(SIMPLEBLE_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Adapter.cpp
@@ -53,8 +58,8 @@ set(SIMPLEBLE_C_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/src_c/logging.cpp)
 
 # Define targets
-add_library(simpleble ${SIMPLEBLE_SRC})
-add_library(simpleble-c ${SIMPLEBLE_C_SRC})
+add_library(simpleble ${_LIBTYPE} ${SIMPLEBLE_SRC})
+add_library(simpleble-c ${_CLIBTYPE} ${SIMPLEBLE_C_SRC})
 
 add_library(simpleble::simpleble ALIAS simpleble)
 add_library(simpleble::simpleble-c ALIAS simpleble-c)
@@ -85,11 +90,26 @@ set_target_properties(simpleble-c PROPERTIES
     EXPORT_NAME simpleble-c
     OUTPUT_NAME simpleble-c)
 
-# Configure include directories
-target_include_directories(simpleble PRIVATE ${SIMPLEBLE_PRIVATE_INCLUDES})
-target_include_directories(simpleble-c PRIVATE ${SIMPLEBLE_PRIVATE_INCLUDES})
-target_include_directories(simpleble INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_include_directories(simpleble-c INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_include_directories(simpleble
+    PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/builders>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/external>
+    PUBLIC
+        $<INSTALL_INTERFACE:include>
+)
+target_include_directories(simpleble-c
+    PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/builders>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/external>
+    PUBLIC
+        $<INSTALL_INTERFACE:include>
+)
 
 # Configure linked libraries
 target_link_libraries(simpleble PRIVATE fmt::fmt-header-only)
@@ -159,9 +179,6 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
         ${CMAKE_CURRENT_SOURCE_DIR}/../simplebluez/include
         ${CMAKE_CURRENT_SOURCE_DIR}/../simpledbus/include
         ${CMAKE_CURRENT_SOURCE_DIR}/src/linux)
-    # target_include_directories(simpleble-c PRIVATE
-    #     ${CMAKE_CURRENT_SOURCE_DIR}/../simplebluez/include
-    #     ${CMAKE_CURRENT_SOURCE_DIR}/../simpledbus/include)
 
 
 elseif (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
@@ -195,8 +212,6 @@ elseif (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
 elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
     message(STATUS "Darwin Host Detected")
 
-
-
     list(APPEND PRIVATE_COMPILE_OPTIONS -fobjc-arc)
 
     target_link_libraries(simpleble PUBLIC "-framework Foundation" "-framework CoreBluetooth" ObjC)
@@ -224,7 +239,18 @@ apply_build_options(simpleble-c
     "${PRIVATE_LINK_OPTIONS}"
     "${PUBLIC_LINK_OPTIONS}")
 
-# Build tests if requested
+get_property(SIMPLEBLE_TYPE TARGET simpleble PROPERTY TYPE)
+if(NOT ${SIMPLEBLE_TYPE} STREQUAL "STATIC_LIBRARY")
+    target_compile_definitions(simpleble PUBLIC SIMPLEBLE_SHARED)
+endif()
+
+get_property(SIMPLEBLE_C_TYPE TARGET simpleble-c PROPERTY TYPE)
+if(NOT ${SIMPLEBLE_C_TYPE} STREQUAL "STATIC_LIBRARY")
+    target_compile_definitions(simpleble-c PUBLIC SIMPLEBLE_C_SHARED)
+endif()
+
+target_compile_definitions(simpleble PRIVATE SIMPLEBLE_BUILD)
+target_compile_definitions(simpleble-c PRIVATE SIMPLEBLE_C_BUILD)
 
 if(SIMPLEBLE_TEST)
     message(STATUS "Building Tests")
@@ -246,29 +272,19 @@ if(SIMPLEBLE_TEST)
     target_include_directories(simpleble_test PRIVATE ${GTEST_INCLUDE_DIRS})
 endif()
 
-# Provide installation interface
-
-#     include(GNUInstallDirs)
-
-#     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/simplebluez.pc.in
-#                 ${CMAKE_CURRENT_BINARY_DIR}/simplebluez.pc @ONLY)
-
-#     install(
-#         TARGETS simplebluez ${SIMPLEDBUS_TARGET}
-#         EXPORT simplebluez-config
-#         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-#         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-#         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-
-#     install(
-#         EXPORT simplebluez-config
-#         NAMESPACE simplebluez::
-#         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/simplebluez)
-
-#     install(
-#         DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/simplebluez/
-#         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/simplebluez)
-
-#     install(
-#         FILES ${CMAKE_CURRENT_BINARY_DIR}/simplebluez.pc
-#         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+install_target(simpleble
+    VERSION ${PROJECT_VERSION}
+    EXPORT simpleble
+    NAMESPACE simpleble
+    CMAKE_INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/simpleble-config.cmake.in
+    CMAKE_OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/simpleble-config.cmake
+)
+install_target(simpleble-c
+    VERSION ${PROJECT_VERSION}
+    EXPORT simpleble-c
+    NAMESPACE simpleble
+    CMAKE_INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/simpleble-c-config.cmake.in
+    CMAKE_OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/simpleble-c-config.cmake
+)
+install(DIRECTORY include/ TYPE INCLUDE
+    FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")

--- a/simpleble/CMakeLists.txt
+++ b/simpleble/CMakeLists.txt
@@ -17,6 +17,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/prelude.cmake)
 option(LIBFMT_VENDORIZE "Enable vendorized libfmt" ON)
 option(BUILD_SIMPLEBLE_SHARED "Build as a shared library" OFF)
 option(BUILD_SIMPLEBLE_C_SHARED "Build SimpleBLE-C as a shared library" OFF)
+option(NO_SONAME "Build as a plugin" OFF)
 
 find_package(fmt REQUIRED)
 
@@ -247,6 +248,11 @@ endif()
 get_property(SIMPLEBLE_C_TYPE TARGET simpleble-c PROPERTY TYPE)
 if(NOT ${SIMPLEBLE_C_TYPE} STREQUAL "STATIC_LIBRARY")
     target_compile_definitions(simpleble-c PUBLIC SIMPLEBLE_C_SHARED)
+endif()
+
+if(NO_SONAME)
+    set_target_properties(simpleble PROPERTIES NO_SONAME ON)
+    set_target_properties(simpleble-c PROPERTIES NO_SONAME ON)
 endif()
 
 target_compile_definitions(simpleble PRIVATE SIMPLEBLE_BUILD)

--- a/simpleble/CMakeLists.txt
+++ b/simpleble/CMakeLists.txt
@@ -94,20 +94,20 @@ target_include_directories(simpleble
     PRIVATE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/builders>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/external>
     PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
 )
 target_include_directories(simpleble-c
-    PRIVATE
+    INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/builders>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/external>
     PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
 )
 

--- a/simpleble/include/simpleble/Adapter.h
+++ b/simpleble/include/simpleble/Adapter.h
@@ -5,8 +5,8 @@
 #include <string>
 #include <vector>
 
-#include <simpleble/Export.h>
 #include <simpleble/Exceptions.h>
+#include <simpleble/Export.h>
 #include <simpleble/Peripheral.h>
 #include <simpleble/Types.h>
 

--- a/simpleble/include/simpleble/Adapter.h
+++ b/simpleble/include/simpleble/Adapter.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include <simpleble/Export.h>
 #include <simpleble/Exceptions.h>
 #include <simpleble/Peripheral.h>
 #include <simpleble/Types.h>
@@ -13,7 +14,7 @@ namespace SimpleBLE {
 
 class AdapterBase;
 
-class Adapter {
+class SIMPLEBLE_EXPORT Adapter {
   public:
     Adapter() = default;
     virtual ~Adapter() = default;

--- a/simpleble/include/simpleble/AdapterSafe.h
+++ b/simpleble/include/simpleble/AdapterSafe.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <simpleble/Export.h>
 #include <simpleble/Adapter.h>
 #include <simpleble/PeripheralSafe.h>
 
@@ -7,7 +8,7 @@ namespace SimpleBLE {
 
 namespace Safe {
 
-class Adapter : public SimpleBLE::Adapter {
+class SIMPLEBLE_EXPORT Adapter : public SimpleBLE::Adapter {
   public:
     Adapter(SimpleBLE::Adapter& adapter);
     virtual ~Adapter() = default;

--- a/simpleble/include/simpleble/AdapterSafe.h
+++ b/simpleble/include/simpleble/AdapterSafe.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <simpleble/Export.h>
 #include <simpleble/Adapter.h>
+#include <simpleble/Export.h>
 #include <simpleble/PeripheralSafe.h>
 
 namespace SimpleBLE {

--- a/simpleble/include/simpleble/Characteristic.h
+++ b/simpleble/include/simpleble/Characteristic.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include <simpleble/Export.h>
 #include <simpleble/Descriptor.h>
 #include <simpleble/Exceptions.h>
 #include <simpleble/Types.h>
@@ -10,7 +11,7 @@ namespace SimpleBLE {
 
 class CharacteristicBase;
 
-class Characteristic {
+class SIMPLEBLE_EXPORT Characteristic {
   public:
     Characteristic() = default;
     virtual ~Characteristic() = default;

--- a/simpleble/include/simpleble/Characteristic.h
+++ b/simpleble/include/simpleble/Characteristic.h
@@ -2,9 +2,9 @@
 
 #include <memory>
 
-#include <simpleble/Export.h>
 #include <simpleble/Descriptor.h>
 #include <simpleble/Exceptions.h>
+#include <simpleble/Export.h>
 #include <simpleble/Types.h>
 
 namespace SimpleBLE {

--- a/simpleble/include/simpleble/Descriptor.h
+++ b/simpleble/include/simpleble/Descriptor.h
@@ -2,8 +2,8 @@
 
 #include <memory>
 
-#include <simpleble/Export.h>
 #include <simpleble/Exceptions.h>
+#include <simpleble/Export.h>
 #include <simpleble/Types.h>
 
 namespace SimpleBLE {

--- a/simpleble/include/simpleble/Descriptor.h
+++ b/simpleble/include/simpleble/Descriptor.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include <simpleble/Export.h>
 #include <simpleble/Exceptions.h>
 #include <simpleble/Types.h>
 
@@ -9,7 +10,7 @@ namespace SimpleBLE {
 
 class DescriptorBase;
 
-class Descriptor {
+class SIMPLEBLE_EXPORT Descriptor {
   public:
     Descriptor() = default;
     virtual ~Descriptor() = default;

--- a/simpleble/include/simpleble/Exceptions.h
+++ b/simpleble/include/simpleble/Exceptions.h
@@ -2,63 +2,64 @@
 
 #include <stdexcept>
 #include <string>
+#include <simpleble/Export.h>
 #include "Types.h"
 
 namespace SimpleBLE {
 
 namespace Exception {
 
-class BaseException : public std::runtime_error {
+class SIMPLEBLE_EXPORT BaseException : public std::runtime_error {
   public:
     BaseException(const std::string& __arg) : std::runtime_error(__arg) {}
 };
 
-class NotInitialized : public BaseException {
+class SIMPLEBLE_EXPORT NotInitialized : public BaseException {
   public:
     NotInitialized();
 };
 
-class NotConnected : public BaseException {
+class SIMPLEBLE_EXPORT NotConnected : public BaseException {
   public:
     NotConnected();
 };
 
-class InvalidReference : public BaseException {
+class SIMPLEBLE_EXPORT InvalidReference : public BaseException {
   public:
     InvalidReference();
 };
 
-class ServiceNotFound : public BaseException {
+class SIMPLEBLE_EXPORT ServiceNotFound : public BaseException {
   public:
     ServiceNotFound(BluetoothUUID uuid);
 };
 
-class CharacteristicNotFound : public BaseException {
+class SIMPLEBLE_EXPORT CharacteristicNotFound : public BaseException {
   public:
     CharacteristicNotFound(BluetoothUUID uuid);
 };
 
-class DescriptorNotFound : public BaseException {
+class SIMPLEBLE_EXPORT DescriptorNotFound : public BaseException {
   public:
     DescriptorNotFound(BluetoothUUID uuid);
 };
 
-class OperationNotSupported : public BaseException {
+class SIMPLEBLE_EXPORT OperationNotSupported : public BaseException {
   public:
     OperationNotSupported();
 };
 
-class OperationFailed : public BaseException {
+class SIMPLEBLE_EXPORT OperationFailed : public BaseException {
   public:
     OperationFailed();
 };
 
-class WinRTException : public BaseException {
+class SIMPLEBLE_EXPORT WinRTException : public BaseException {
   public:
     WinRTException(int32_t err_code, const std::string& err_msg);
 };
 
-class CoreBluetoothException : public BaseException {
+class SIMPLEBLE_EXPORT CoreBluetoothException : public BaseException {
   public:
     CoreBluetoothException(const std::string& err_msg);
 };

--- a/simpleble/include/simpleble/Exceptions.h
+++ b/simpleble/include/simpleble/Exceptions.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <simpleble/Export.h>
 #include <stdexcept>
 #include <string>
-#include <simpleble/Export.h>
 #include "Types.h"
 
 namespace SimpleBLE {

--- a/simpleble/include/simpleble/Export.h
+++ b/simpleble/include/simpleble/Export.h
@@ -1,0 +1,22 @@
+#ifndef SIMPLEBLE_EXPORT_H
+#define SIMPLEBLE_EXPORT_H
+
+#ifdef SIMPLEBLE_SHARED
+#    ifdef _MSC_VER
+#        ifdef SIMPLEBLE_BUILD
+#            define SIMPLEBLE_EXPORT __declspec(dllexport)
+#        else
+#            define SIMPLEBLE_EXPORT __declspec(dllimport)
+#        endif
+#    else
+#        ifdef SIMPLEBLE_BUILD
+#            define SIMPLEBLE_EXPORT __attribute__((visibility("default")))
+#        else
+#            define SIMPLEBLE_EXPORT __attribute__((visibility("default")))
+#        endif
+#    endif
+#else
+#    define SIMPLEBLE_EXPORT
+#endif
+
+#endif

--- a/simpleble/include/simpleble/Export.h
+++ b/simpleble/include/simpleble/Export.h
@@ -2,21 +2,21 @@
 #define SIMPLEBLE_EXPORT_H
 
 #ifdef SIMPLEBLE_SHARED
-#    ifdef _MSC_VER
-#        ifdef SIMPLEBLE_BUILD
-#            define SIMPLEBLE_EXPORT __declspec(dllexport)
-#        else
-#            define SIMPLEBLE_EXPORT __declspec(dllimport)
-#        endif
-#    else
-#        ifdef SIMPLEBLE_BUILD
-#            define SIMPLEBLE_EXPORT __attribute__((visibility("default")))
-#        else
-#            define SIMPLEBLE_EXPORT __attribute__((visibility("default")))
-#        endif
-#    endif
+#ifdef _MSC_VER
+#ifdef SIMPLEBLE_BUILD
+#define SIMPLEBLE_EXPORT __declspec(dllexport)
 #else
-#    define SIMPLEBLE_EXPORT
+#define SIMPLEBLE_EXPORT __declspec(dllimport)
+#endif
+#else
+#ifdef SIMPLEBLE_BUILD
+#define SIMPLEBLE_EXPORT __attribute__((visibility("default")))
+#else
+#define SIMPLEBLE_EXPORT __attribute__((visibility("default")))
+#endif
+#endif
+#else
+#define SIMPLEBLE_EXPORT
 #endif
 
 #endif

--- a/simpleble/include/simpleble/Logging.h
+++ b/simpleble/include/simpleble/Logging.h
@@ -5,6 +5,8 @@
 #include <mutex>
 #include <string>
 
+#include <simpleble/Export.h>
+
 namespace SimpleBLE {
 
 namespace Logging {
@@ -26,7 +28,7 @@ enum Level : int {
 using Callback = std::function<void(Level, const std::string&, const std::string&, uint32_t, const std::string&, const std::string&)>;
 // clang-format on
 
-class Logger {
+class SIMPLEBLE_EXPORT Logger {
   public:
     static Logger* get();
 

--- a/simpleble/include/simpleble/Peripheral.h
+++ b/simpleble/include/simpleble/Peripheral.h
@@ -7,8 +7,8 @@
 #include <string>
 #include <vector>
 
-#include <simpleble/Export.h>
 #include <simpleble/Exceptions.h>
+#include <simpleble/Export.h>
 #include <simpleble/Service.h>
 #include <simpleble/Types.h>
 

--- a/simpleble/include/simpleble/Peripheral.h
+++ b/simpleble/include/simpleble/Peripheral.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include <simpleble/Export.h>
 #include <simpleble/Exceptions.h>
 #include <simpleble/Service.h>
 #include <simpleble/Types.h>
@@ -15,7 +16,7 @@ namespace SimpleBLE {
 
 class PeripheralBase;
 
-class Peripheral {
+class SIMPLEBLE_EXPORT Peripheral {
   public:
     Peripheral() = default;
     virtual ~Peripheral() = default;

--- a/simpleble/include/simpleble/PeripheralSafe.h
+++ b/simpleble/include/simpleble/PeripheralSafe.h
@@ -2,6 +2,7 @@
 
 #include <optional>
 
+#include <simpleble/Export.h>
 #include <simpleble/Peripheral.h>
 #include <simpleble/Service.h>
 
@@ -9,7 +10,7 @@ namespace SimpleBLE {
 
 namespace Safe {
 
-class Peripheral : public SimpleBLE::Peripheral {
+class SIMPLEBLE_EXPORT Peripheral : public SimpleBLE::Peripheral {
   public:
     Peripheral(SimpleBLE::Peripheral& peripheral);
     virtual ~Peripheral() = default;

--- a/simpleble/include/simpleble/Service.h
+++ b/simpleble/include/simpleble/Service.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 
+#include <simpleble/Export.h>
 #include <simpleble/Exceptions.h>
 #include <simpleble/Types.h>
 #include "simpleble/Characteristic.h"
@@ -11,7 +12,7 @@ namespace SimpleBLE {
 
 class ServiceBase;
 
-class Service {
+class SIMPLEBLE_EXPORT Service {
   public:
     Service() = default;
     virtual ~Service() = default;

--- a/simpleble/include/simpleble/Service.h
+++ b/simpleble/include/simpleble/Service.h
@@ -3,8 +3,8 @@
 #include <memory>
 #include <vector>
 
-#include <simpleble/Export.h>
 #include <simpleble/Exceptions.h>
+#include <simpleble/Export.h>
 #include <simpleble/Types.h>
 #include "simpleble/Characteristic.h"
 

--- a/simpleble/include/simpleble_c/adapter.h
+++ b/simpleble/include/simpleble_c/adapter.h
@@ -109,7 +109,8 @@ SIMPLEBLE_C_EXPORT size_t simpleble_adapter_scan_get_results_count(simpleble_ada
  * @param index
  * @return simpleble_peripheral_t
  */
-SIMPLEBLE_C_EXPORT simpleble_peripheral_t simpleble_adapter_scan_get_results_handle(simpleble_adapter_t handle, size_t index);
+SIMPLEBLE_C_EXPORT simpleble_peripheral_t simpleble_adapter_scan_get_results_handle(simpleble_adapter_t handle,
+                                                                                    size_t index);
 
 /**
  * @brief
@@ -129,7 +130,8 @@ SIMPLEBLE_C_EXPORT size_t simpleble_adapter_get_paired_peripherals_count(simpleb
  * @param index
  * @return simpleble_peripheral_t
  */
-SIMPLEBLE_C_EXPORT simpleble_peripheral_t simpleble_adapter_get_paired_peripherals_handle(simpleble_adapter_t handle, size_t index);
+SIMPLEBLE_C_EXPORT simpleble_peripheral_t simpleble_adapter_get_paired_peripherals_handle(simpleble_adapter_t handle,
+                                                                                          size_t index);
 
 /**
  * @brief

--- a/simpleble/include/simpleble_c/adapter.h
+++ b/simpleble/include/simpleble_c/adapter.h
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <simpleble_c/export.h>
 #include <simpleble_c/types.h>
 
 #ifdef __cplusplus
@@ -15,7 +16,7 @@ extern "C" {
  *
  * @return size_t
  */
-size_t simpleble_adapter_get_count(void);
+SIMPLEBLE_C_EXPORT size_t simpleble_adapter_get_count(void);
 
 /**
  * @brief
@@ -26,7 +27,7 @@ size_t simpleble_adapter_get_count(void);
  * @param index
  * @return simpleble_adapter_t
  */
-simpleble_adapter_t simpleble_adapter_get_handle(size_t index);
+SIMPLEBLE_C_EXPORT simpleble_adapter_t simpleble_adapter_get_handle(size_t index);
 
 /**
  * @brief Releases all memory and resources consumed by the specific
@@ -34,7 +35,7 @@ simpleble_adapter_t simpleble_adapter_get_handle(size_t index);
  *
  * @param handle
  */
-void simpleble_adapter_release_handle(simpleble_adapter_t handle);
+SIMPLEBLE_C_EXPORT void simpleble_adapter_release_handle(simpleble_adapter_t handle);
 
 /**
  * @brief Returns the identifier of a given adapter.
@@ -44,7 +45,7 @@ void simpleble_adapter_release_handle(simpleble_adapter_t handle);
  * @param handle
  * @return char*
  */
-char* simpleble_adapter_identifier(simpleble_adapter_t handle);
+SIMPLEBLE_C_EXPORT char* simpleble_adapter_identifier(simpleble_adapter_t handle);
 
 /**
  * @brief Returns the MAC address of a given adapter.
@@ -54,7 +55,7 @@ char* simpleble_adapter_identifier(simpleble_adapter_t handle);
  * @param handle
  * @return char*
  */
-char* simpleble_adapter_address(simpleble_adapter_t handle);
+SIMPLEBLE_C_EXPORT char* simpleble_adapter_address(simpleble_adapter_t handle);
 
 /**
  * @brief
@@ -62,7 +63,7 @@ char* simpleble_adapter_address(simpleble_adapter_t handle);
  * @param handle
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_adapter_scan_start(simpleble_adapter_t handle);
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_adapter_scan_start(simpleble_adapter_t handle);
 
 /**
  * @brief
@@ -70,7 +71,7 @@ simpleble_err_t simpleble_adapter_scan_start(simpleble_adapter_t handle);
  * @param handle
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_adapter_scan_stop(simpleble_adapter_t handle);
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_adapter_scan_stop(simpleble_adapter_t handle);
 
 /**
  * @brief
@@ -79,7 +80,7 @@ simpleble_err_t simpleble_adapter_scan_stop(simpleble_adapter_t handle);
  * @param active
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_adapter_scan_is_active(simpleble_adapter_t handle, bool* active);
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_adapter_scan_is_active(simpleble_adapter_t handle, bool* active);
 
 /**
  * @brief
@@ -88,7 +89,7 @@ simpleble_err_t simpleble_adapter_scan_is_active(simpleble_adapter_t handle, boo
  * @param timeout_ms
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_adapter_scan_for(simpleble_adapter_t handle, int timeout_ms);
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_adapter_scan_for(simpleble_adapter_t handle, int timeout_ms);
 
 /**
  * @brief
@@ -96,7 +97,7 @@ simpleble_err_t simpleble_adapter_scan_for(simpleble_adapter_t handle, int timeo
  * @param handle
  * @return size_t
  */
-size_t simpleble_adapter_scan_get_results_count(simpleble_adapter_t handle);
+SIMPLEBLE_C_EXPORT size_t simpleble_adapter_scan_get_results_count(simpleble_adapter_t handle);
 
 /**
  * @brief
@@ -108,7 +109,7 @@ size_t simpleble_adapter_scan_get_results_count(simpleble_adapter_t handle);
  * @param index
  * @return simpleble_peripheral_t
  */
-simpleble_peripheral_t simpleble_adapter_scan_get_results_handle(simpleble_adapter_t handle, size_t index);
+SIMPLEBLE_C_EXPORT simpleble_peripheral_t simpleble_adapter_scan_get_results_handle(simpleble_adapter_t handle, size_t index);
 
 /**
  * @brief
@@ -116,7 +117,7 @@ simpleble_peripheral_t simpleble_adapter_scan_get_results_handle(simpleble_adapt
  * @param handle
  * @return size_t
  */
-size_t simpleble_adapter_get_paired_peripherals_count(simpleble_adapter_t handle);
+SIMPLEBLE_C_EXPORT size_t simpleble_adapter_get_paired_peripherals_count(simpleble_adapter_t handle);
 
 /**
  * @brief
@@ -128,7 +129,7 @@ size_t simpleble_adapter_get_paired_peripherals_count(simpleble_adapter_t handle
  * @param index
  * @return simpleble_peripheral_t
  */
-simpleble_peripheral_t simpleble_adapter_get_paired_peripherals_handle(simpleble_adapter_t handle, size_t index);
+SIMPLEBLE_C_EXPORT simpleble_peripheral_t simpleble_adapter_get_paired_peripherals_handle(simpleble_adapter_t handle, size_t index);
 
 /**
  * @brief
@@ -137,7 +138,7 @@ simpleble_peripheral_t simpleble_adapter_get_paired_peripherals_handle(simpleble
  * @param callback
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_adapter_set_callback_on_scan_start(
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_adapter_set_callback_on_scan_start(
     simpleble_adapter_t handle, void (*callback)(simpleble_adapter_t adapter, void* userdata), void* userdata);
 
 /**
@@ -147,7 +148,7 @@ simpleble_err_t simpleble_adapter_set_callback_on_scan_start(
  * @param callback
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_adapter_set_callback_on_scan_stop(
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_adapter_set_callback_on_scan_stop(
     simpleble_adapter_t handle, void (*callback)(simpleble_adapter_t adapter, void* userdata), void* userdata);
 
 /**
@@ -157,7 +158,7 @@ simpleble_err_t simpleble_adapter_set_callback_on_scan_stop(
  * @param callback
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_adapter_set_callback_on_scan_updated(
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_adapter_set_callback_on_scan_updated(
     simpleble_adapter_t handle,
     void (*callback)(simpleble_adapter_t adapter, simpleble_peripheral_t peripheral, void* userdata), void* userdata);
 
@@ -168,7 +169,7 @@ simpleble_err_t simpleble_adapter_set_callback_on_scan_updated(
  * @param callback
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_adapter_set_callback_on_scan_found(
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_adapter_set_callback_on_scan_found(
     simpleble_adapter_t handle,
     void (*callback)(simpleble_adapter_t adapter, simpleble_peripheral_t peripheral, void* userdata), void* userdata);
 

--- a/simpleble/include/simpleble_c/export.h
+++ b/simpleble/include/simpleble_c/export.h
@@ -1,0 +1,22 @@
+#ifndef SIMPLEBLE_C_EXPORT_H
+#define SIMPLEBLE_C_EXPORT_H
+
+#ifdef SIMPLEBLE_C_SHARED
+#    ifdef _MSC_VER
+#        ifdef SIMPLEBLE_C_BUILD
+#            define SIMPLEBLE_C_EXPORT __declspec(dllexport)
+#        else
+#            define SIMPLEBLE_C_EXPORT __declspec(dllimport)
+#        endif
+#    else
+#        ifdef SIMPLEBLE_C_BUILD
+#            define SIMPLEBLE_C_EXPORT __attribute__((visibility("default")))
+#        else
+#            define SIMPLEBLE_C_EXPORT __attribute__((visibility("default")))
+#        endif
+#    endif
+#else
+#    define SIMPLEBLE_C_EXPORT
+#endif
+
+#endif

--- a/simpleble/include/simpleble_c/export.h
+++ b/simpleble/include/simpleble_c/export.h
@@ -2,21 +2,21 @@
 #define SIMPLEBLE_C_EXPORT_H
 
 #ifdef SIMPLEBLE_C_SHARED
-#    ifdef _MSC_VER
-#        ifdef SIMPLEBLE_C_BUILD
-#            define SIMPLEBLE_C_EXPORT __declspec(dllexport)
-#        else
-#            define SIMPLEBLE_C_EXPORT __declspec(dllimport)
-#        endif
-#    else
-#        ifdef SIMPLEBLE_C_BUILD
-#            define SIMPLEBLE_C_EXPORT __attribute__((visibility("default")))
-#        else
-#            define SIMPLEBLE_C_EXPORT __attribute__((visibility("default")))
-#        endif
-#    endif
+#ifdef _MSC_VER
+#ifdef SIMPLEBLE_C_BUILD
+#define SIMPLEBLE_C_EXPORT __declspec(dllexport)
 #else
-#    define SIMPLEBLE_C_EXPORT
+#define SIMPLEBLE_C_EXPORT __declspec(dllimport)
+#endif
+#else
+#ifdef SIMPLEBLE_C_BUILD
+#define SIMPLEBLE_C_EXPORT __attribute__((visibility("default")))
+#else
+#define SIMPLEBLE_C_EXPORT __attribute__((visibility("default")))
+#endif
+#endif
+#else
+#define SIMPLEBLE_C_EXPORT
 #endif
 
 #endif

--- a/simpleble/include/simpleble_c/logging.h
+++ b/simpleble/include/simpleble_c/logging.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <simpleble_c/export.h>
 
 typedef enum {
     SIMPLEBLE_LOG_LEVEL_NONE = 0,
@@ -27,8 +28,8 @@ typedef void (*simpleble_log_callback_t)(
 extern "C" {
 #endif
 
-void simpleble_logging_set_level(simpleble_log_level_t level);
-void simpleble_logging_set_callback(simpleble_log_callback_t callback);
+SIMPLEBLE_C_EXPORT void simpleble_logging_set_level(simpleble_log_level_t level);
+SIMPLEBLE_C_EXPORT void simpleble_logging_set_callback(simpleble_log_callback_t callback);
 
 #ifdef __cplusplus
 }

--- a/simpleble/include/simpleble_c/logging.h
+++ b/simpleble/include/simpleble_c/logging.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <stdint.h>
 #include <simpleble_c/export.h>
+#include <stdint.h>
 
 typedef enum {
     SIMPLEBLE_LOG_LEVEL_NONE = 0,

--- a/simpleble/include/simpleble_c/peripheral.h
+++ b/simpleble/include/simpleble_c/peripheral.h
@@ -75,7 +75,8 @@ SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_is_connected(simpleble_p
  * @param connectable
  * @return simpleble_err_t
  */
-SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_is_connectable(simpleble_peripheral_t handle, bool* connectable);
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_is_connectable(simpleble_peripheral_t handle,
+                                                                       bool* connectable);
 
 /**
  * @brief
@@ -111,7 +112,7 @@ SIMPLEBLE_C_EXPORT size_t simpleble_peripheral_services_count(simpleble_peripher
  * @return simpleble_err_t
  */
 SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_services_get(simpleble_peripheral_t handle, size_t index,
-                                                  simpleble_service_t* services);
+                                                                     simpleble_service_t* services);
 
 /**
  * @brief
@@ -129,8 +130,8 @@ SIMPLEBLE_C_EXPORT size_t simpleble_peripheral_manufacturer_data_count(simpleble
  * @param manufacturer_data
  * @return simpleble_err_t
  */
-SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_manufacturer_data_get(simpleble_peripheral_t handle, size_t index,
-                                                           simpleble_manufacturer_data_t* manufacturer_data);
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_manufacturer_data_get(
+    simpleble_peripheral_t handle, size_t index, simpleble_manufacturer_data_t* manufacturer_data);
 
 /**
  * @brief
@@ -145,7 +146,8 @@ SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_manufacturer_data_get(si
  * @return simpleble_err_t
  */
 SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_read(simpleble_peripheral_t handle, simpleble_uuid_t service,
-                                          simpleble_uuid_t characteristic, uint8_t** data, size_t* data_length);
+                                                             simpleble_uuid_t characteristic, uint8_t** data,
+                                                             size_t* data_length);
 
 /**
  * @brief
@@ -157,9 +159,10 @@ SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_read(simpleble_periphera
  * @param data_length
  * @return simpleble_err_t
  */
-SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_write_request(simpleble_peripheral_t handle, simpleble_uuid_t service,
-                                                   simpleble_uuid_t characteristic, const uint8_t* data,
-                                                   size_t data_length);
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_write_request(simpleble_peripheral_t handle,
+                                                                      simpleble_uuid_t service,
+                                                                      simpleble_uuid_t characteristic,
+                                                                      const uint8_t* data, size_t data_length);
 
 /**
  * @brief
@@ -171,9 +174,10 @@ SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_write_request(simpleble_
  * @param data_length
  * @return simpleble_err_t
  */
-SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_write_command(simpleble_peripheral_t handle, simpleble_uuid_t service,
-                                                   simpleble_uuid_t characteristic, const uint8_t* data,
-                                                   size_t data_length);
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_write_command(simpleble_peripheral_t handle,
+                                                                      simpleble_uuid_t service,
+                                                                      simpleble_uuid_t characteristic,
+                                                                      const uint8_t* data, size_t data_length);
 
 /**
  * @brief
@@ -184,11 +188,11 @@ SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_write_command(simpleble_
  * @param callback
  * @return simpleble_err_t
  */
-SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_notify(simpleble_peripheral_t handle, simpleble_uuid_t service,
-                                            simpleble_uuid_t characteristic,
-                                            void (*callback)(simpleble_uuid_t service, simpleble_uuid_t characteristic,
-                                                             const uint8_t* data, size_t data_length, void* userdata),
-                                            void* userdata);
+SIMPLEBLE_C_EXPORT simpleble_err_t
+simpleble_peripheral_notify(simpleble_peripheral_t handle, simpleble_uuid_t service, simpleble_uuid_t characteristic,
+                            void (*callback)(simpleble_uuid_t service, simpleble_uuid_t characteristic,
+                                             const uint8_t* data, size_t data_length, void* userdata),
+                            void* userdata);
 
 /**
  * @brief
@@ -199,12 +203,11 @@ SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_notify(simpleble_periphe
  * @param callback
  * @return simpleble_err_t
  */
-SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_indicate(simpleble_peripheral_t handle, simpleble_uuid_t service,
-                                              simpleble_uuid_t characteristic,
-                                              void (*callback)(simpleble_uuid_t service,
-                                                               simpleble_uuid_t characteristic, const uint8_t* data,
-                                                               size_t data_length, void* userdata),
-                                              void* userdata);
+SIMPLEBLE_C_EXPORT simpleble_err_t
+simpleble_peripheral_indicate(simpleble_peripheral_t handle, simpleble_uuid_t service, simpleble_uuid_t characteristic,
+                              void (*callback)(simpleble_uuid_t service, simpleble_uuid_t characteristic,
+                                               const uint8_t* data, size_t data_length, void* userdata),
+                              void* userdata);
 
 /**
  * @brief
@@ -214,8 +217,9 @@ SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_indicate(simpleble_perip
  * @param characteristic
  * @return simpleble_err_t
  */
-SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_unsubscribe(simpleble_peripheral_t handle, simpleble_uuid_t service,
-                                                 simpleble_uuid_t characteristic);
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_unsubscribe(simpleble_peripheral_t handle,
+                                                                    simpleble_uuid_t service,
+                                                                    simpleble_uuid_t characteristic);
 
 /**
  * @brief
@@ -228,9 +232,11 @@ SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_unsubscribe(simpleble_pe
  * @param data_length
  * @return simpleble_err_t
  */
-SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_read_descriptor(simpleble_peripheral_t handle, simpleble_uuid_t service,
-                                                     simpleble_uuid_t characteristic, simpleble_uuid_t descriptor,
-                                                     uint8_t** data, size_t* data_length);
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_read_descriptor(simpleble_peripheral_t handle,
+                                                                        simpleble_uuid_t service,
+                                                                        simpleble_uuid_t characteristic,
+                                                                        simpleble_uuid_t descriptor, uint8_t** data,
+                                                                        size_t* data_length);
 
 /**
  * @brief
@@ -243,9 +249,11 @@ SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_read_descriptor(simplebl
  * @param data_length
  * @return simpleble_err_t
  */
-SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_write_descriptor(simpleble_peripheral_t handle, simpleble_uuid_t service,
-                                                      simpleble_uuid_t characteristic, simpleble_uuid_t descriptor,
-                                                      const uint8_t* data, size_t data_length);
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_write_descriptor(simpleble_peripheral_t handle,
+                                                                         simpleble_uuid_t service,
+                                                                         simpleble_uuid_t characteristic,
+                                                                         simpleble_uuid_t descriptor,
+                                                                         const uint8_t* data, size_t data_length);
 
 /**
  * @brief

--- a/simpleble/include/simpleble_c/peripheral.h
+++ b/simpleble/include/simpleble_c/peripheral.h
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <simpleble_c/export.h>
 #include <simpleble_c/types.h>
 
 #ifdef __cplusplus
@@ -16,7 +17,7 @@ extern "C" {
  *
  * @param handle
  */
-void simpleble_peripheral_release_handle(simpleble_peripheral_t handle);
+SIMPLEBLE_C_EXPORT void simpleble_peripheral_release_handle(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -24,7 +25,7 @@ void simpleble_peripheral_release_handle(simpleble_peripheral_t handle);
  * @param handle
  * @return char*
  */
-char* simpleble_peripheral_identifier(simpleble_peripheral_t handle);
+SIMPLEBLE_C_EXPORT char* simpleble_peripheral_identifier(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -32,7 +33,7 @@ char* simpleble_peripheral_identifier(simpleble_peripheral_t handle);
  * @param handle
  * @return char*
  */
-char* simpleble_peripheral_address(simpleble_peripheral_t handle);
+SIMPLEBLE_C_EXPORT char* simpleble_peripheral_address(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -40,7 +41,7 @@ char* simpleble_peripheral_address(simpleble_peripheral_t handle);
  * @param handle
  * @return int16_t
  */
-int16_t simpleble_peripheral_rssi(simpleble_peripheral_t handle);
+SIMPLEBLE_C_EXPORT int16_t simpleble_peripheral_rssi(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -48,7 +49,7 @@ int16_t simpleble_peripheral_rssi(simpleble_peripheral_t handle);
  * @param handle
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_connect(simpleble_peripheral_t handle);
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_connect(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -56,7 +57,7 @@ simpleble_err_t simpleble_peripheral_connect(simpleble_peripheral_t handle);
  * @param handle
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_disconnect(simpleble_peripheral_t handle);
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_disconnect(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -65,7 +66,7 @@ simpleble_err_t simpleble_peripheral_disconnect(simpleble_peripheral_t handle);
  * @param connected
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_is_connected(simpleble_peripheral_t handle, bool* connected);
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_is_connected(simpleble_peripheral_t handle, bool* connected);
 
 /**
  * @brief
@@ -74,7 +75,7 @@ simpleble_err_t simpleble_peripheral_is_connected(simpleble_peripheral_t handle,
  * @param connectable
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_is_connectable(simpleble_peripheral_t handle, bool* connectable);
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_is_connectable(simpleble_peripheral_t handle, bool* connectable);
 
 /**
  * @brief
@@ -83,7 +84,7 @@ simpleble_err_t simpleble_peripheral_is_connectable(simpleble_peripheral_t handl
  * @param paired
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_is_paired(simpleble_peripheral_t handle, bool* paired);
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_is_paired(simpleble_peripheral_t handle, bool* paired);
 
 /**
  * @brief
@@ -91,7 +92,7 @@ simpleble_err_t simpleble_peripheral_is_paired(simpleble_peripheral_t handle, bo
  * @param handle
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_unpair(simpleble_peripheral_t handle);
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_unpair(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -99,7 +100,7 @@ simpleble_err_t simpleble_peripheral_unpair(simpleble_peripheral_t handle);
  * @param handle
  * @return size_t
  */
-size_t simpleble_peripheral_services_count(simpleble_peripheral_t handle);
+SIMPLEBLE_C_EXPORT size_t simpleble_peripheral_services_count(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -109,7 +110,7 @@ size_t simpleble_peripheral_services_count(simpleble_peripheral_t handle);
  * @param services
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_services_get(simpleble_peripheral_t handle, size_t index,
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_services_get(simpleble_peripheral_t handle, size_t index,
                                                   simpleble_service_t* services);
 
 /**
@@ -118,7 +119,7 @@ simpleble_err_t simpleble_peripheral_services_get(simpleble_peripheral_t handle,
  * @param handle
  * @return size_t
  */
-size_t simpleble_peripheral_manufacturer_data_count(simpleble_peripheral_t handle);
+SIMPLEBLE_C_EXPORT size_t simpleble_peripheral_manufacturer_data_count(simpleble_peripheral_t handle);
 
 /**
  * @brief
@@ -128,7 +129,7 @@ size_t simpleble_peripheral_manufacturer_data_count(simpleble_peripheral_t handl
  * @param manufacturer_data
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_manufacturer_data_get(simpleble_peripheral_t handle, size_t index,
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_manufacturer_data_get(simpleble_peripheral_t handle, size_t index,
                                                            simpleble_manufacturer_data_t* manufacturer_data);
 
 /**
@@ -143,7 +144,7 @@ simpleble_err_t simpleble_peripheral_manufacturer_data_get(simpleble_peripheral_
  * @param data_length
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_read(simpleble_peripheral_t handle, simpleble_uuid_t service,
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_read(simpleble_peripheral_t handle, simpleble_uuid_t service,
                                           simpleble_uuid_t characteristic, uint8_t** data, size_t* data_length);
 
 /**
@@ -156,7 +157,7 @@ simpleble_err_t simpleble_peripheral_read(simpleble_peripheral_t handle, simpleb
  * @param data_length
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_write_request(simpleble_peripheral_t handle, simpleble_uuid_t service,
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_write_request(simpleble_peripheral_t handle, simpleble_uuid_t service,
                                                    simpleble_uuid_t characteristic, const uint8_t* data,
                                                    size_t data_length);
 
@@ -170,7 +171,7 @@ simpleble_err_t simpleble_peripheral_write_request(simpleble_peripheral_t handle
  * @param data_length
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_write_command(simpleble_peripheral_t handle, simpleble_uuid_t service,
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_write_command(simpleble_peripheral_t handle, simpleble_uuid_t service,
                                                    simpleble_uuid_t characteristic, const uint8_t* data,
                                                    size_t data_length);
 
@@ -183,7 +184,7 @@ simpleble_err_t simpleble_peripheral_write_command(simpleble_peripheral_t handle
  * @param callback
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_notify(simpleble_peripheral_t handle, simpleble_uuid_t service,
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_notify(simpleble_peripheral_t handle, simpleble_uuid_t service,
                                             simpleble_uuid_t characteristic,
                                             void (*callback)(simpleble_uuid_t service, simpleble_uuid_t characteristic,
                                                              const uint8_t* data, size_t data_length, void* userdata),
@@ -198,7 +199,7 @@ simpleble_err_t simpleble_peripheral_notify(simpleble_peripheral_t handle, simpl
  * @param callback
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_indicate(simpleble_peripheral_t handle, simpleble_uuid_t service,
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_indicate(simpleble_peripheral_t handle, simpleble_uuid_t service,
                                               simpleble_uuid_t characteristic,
                                               void (*callback)(simpleble_uuid_t service,
                                                                simpleble_uuid_t characteristic, const uint8_t* data,
@@ -213,7 +214,7 @@ simpleble_err_t simpleble_peripheral_indicate(simpleble_peripheral_t handle, sim
  * @param characteristic
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_unsubscribe(simpleble_peripheral_t handle, simpleble_uuid_t service,
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_unsubscribe(simpleble_peripheral_t handle, simpleble_uuid_t service,
                                                  simpleble_uuid_t characteristic);
 
 /**
@@ -227,7 +228,7 @@ simpleble_err_t simpleble_peripheral_unsubscribe(simpleble_peripheral_t handle, 
  * @param data_length
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_read_descriptor(simpleble_peripheral_t handle, simpleble_uuid_t service,
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_read_descriptor(simpleble_peripheral_t handle, simpleble_uuid_t service,
                                                      simpleble_uuid_t characteristic, simpleble_uuid_t descriptor,
                                                      uint8_t** data, size_t* data_length);
 
@@ -242,7 +243,7 @@ simpleble_err_t simpleble_peripheral_read_descriptor(simpleble_peripheral_t hand
  * @param data_length
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_write_descriptor(simpleble_peripheral_t handle, simpleble_uuid_t service,
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_write_descriptor(simpleble_peripheral_t handle, simpleble_uuid_t service,
                                                       simpleble_uuid_t characteristic, simpleble_uuid_t descriptor,
                                                       const uint8_t* data, size_t data_length);
 
@@ -253,7 +254,7 @@ simpleble_err_t simpleble_peripheral_write_descriptor(simpleble_peripheral_t han
  * @param callback
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_set_callback_on_connected(
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_set_callback_on_connected(
     simpleble_peripheral_t handle, void (*callback)(simpleble_peripheral_t peripheral, void* userdata), void* userdata);
 
 /**
@@ -263,7 +264,7 @@ simpleble_err_t simpleble_peripheral_set_callback_on_connected(
  * @param callback
  * @return simpleble_err_t
  */
-simpleble_err_t simpleble_peripheral_set_callback_on_disconnected(
+SIMPLEBLE_C_EXPORT simpleble_err_t simpleble_peripheral_set_callback_on_disconnected(
     simpleble_peripheral_t handle, void (*callback)(simpleble_peripheral_t peripheral, void* userdata), void* userdata);
 
 #ifdef __cplusplus

--- a/simpleble/include/simpleble_c/simpleble.h
+++ b/simpleble/include/simpleble_c/simpleble.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <simpleble_c/export.h>
 #include <simpleble_c/adapter.h>
+#include <simpleble_c/export.h>
 #include <simpleble_c/peripheral.h>
 
 #ifdef __cplusplus

--- a/simpleble/include/simpleble_c/simpleble.h
+++ b/simpleble/include/simpleble_c/simpleble.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <simpleble_c/export.h>
 #include <simpleble_c/adapter.h>
 #include <simpleble_c/peripheral.h>
 
@@ -13,7 +14,7 @@ extern "C" {
  *
  * @param handle
  */
-void simpleble_free(void* handle);
+SIMPLEBLE_C_EXPORT void simpleble_free(void* handle);
 
 #ifdef __cplusplus
 }

--- a/simpleble/simpleble-c-config.cmake.in
+++ b/simpleble/simpleble-c-config.cmake.in
@@ -1,0 +1,26 @@
+#.rst:
+# simpleble-c-config
+# ------------------
+# 
+# CMake package for using SimpleBLE-C.
+#
+# IMPORTED Targets
+# ^^^^^^^^^^^^^^^^
+# 
+# This module defines the :prop_tgt:`IMPORTED` target ``simpleble::simpleble-c``
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+
+@PACKAGE_INIT@
+
+set(TARGET_FILE "${CMAKE_CURRENT_LIST_DIR}/simpleble-c-targets.cmake")
+
+include(${TARGET_FILE} OPTIONAL RESULT_VARIABLE ret)
+if(NOT ret)
+    set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)
+    set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE "${TARGET_FILE} not found.")
+    return()
+endif()
+
+# Mark the CMake package as FOUND.
+set(${CMAKE_FIND_PACKAGE_NAME}_FOUND TRUE)

--- a/simpleble/simpleble-config.cmake.in
+++ b/simpleble/simpleble-config.cmake.in
@@ -1,0 +1,26 @@
+#.rst:
+# simpleble-config
+# ----------------
+# 
+# CMake package for using SimpleBLE.
+#
+# IMPORTED Targets
+# ^^^^^^^^^^^^^^^^
+# 
+# This module defines the :prop_tgt:`IMPORTED` target ``simpleble::simpleble``
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+
+@PACKAGE_INIT@
+
+set(TARGET_FILE "${CMAKE_CURRENT_LIST_DIR}/simpleble-targets.cmake")
+
+include(${TARGET_FILE} OPTIONAL RESULT_VARIABLE ret)
+if(NOT ret)
+    set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)
+    set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE "${TARGET_FILE} not found.")
+    return()
+endif()
+
+# Mark the CMake package as FOUND.
+set(${CMAKE_FIND_PACKAGE_NAME}_FOUND TRUE)

--- a/simplebluez/CMakeLists.txt
+++ b/simplebluez/CMakeLists.txt
@@ -12,12 +12,17 @@ project(
 include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/prelude.cmake)
 
 option(LIBFMT_VENDORIZE "Enable vendorized libfmt" ON)
+option(BUILD_SIMPLEBLUEZ_SHARED "Build as a shared library" OFF)
 
 find_package(fmt REQUIRED)
 find_package(DBus1 REQUIRED)
 
 if(NOT DEFINED SIMPLEDBUS_SANITIZE AND DEFINED SIMPLEBLUEZ_SANITIZE)
     set(SIMPLEDBUS_SANITIZE ${SIMPLEBLUEZ_SANITIZE})
+endif()
+
+if(BUILD_SIMPLEBLUEZ_SHARED)
+    set(_LIBTYPE "SHARED")
 endif()
 
 # Load all variables that would eventually need to be exposed to downstream projects
@@ -28,10 +33,6 @@ endif()
 if(NOT SIMPLEBLUEZ_LOG_LEVEL)
     set(SIMPLEBLUEZ_LOG_LEVEL "FATAL")
 endif()
-
-set(SIMPLEBLUEZ_INCLUDE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/../simpledbus/include)
 
 set(SIMPLEBLUEZ_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ProxyOrg.cpp
@@ -66,7 +67,7 @@ set(SIMPLEBLUEZ_SRC
 
 # Configure the build targets
 
-add_library(simplebluez ${SIMPLEBLUEZ_SRC})
+add_library(simplebluez ${_LIBTYPE} ${SIMPLEBLUEZ_SRC})
 add_library(simplebluez::simplebluez ALIAS simplebluez)
 
 set_target_properties(
@@ -83,14 +84,25 @@ set_target_properties(
 
 list(APPEND PRIVATE_COMPILE_DEFINITIONS SIMPLEDBUS_LOG_LEVEL=${SIMPLEDBUS_LOG_LEVEL})
 list(APPEND PRIVATE_COMPILE_DEFINITIONS SIMPLEBLUEZ_LOG_LEVEL=${SIMPLEBLUEZ_LOG_LEVEL})
+list(APPEND PRIVATE_COMPILE_DEFINITIONS SIMPLEBLUEZ_BUILD)
+
+get_property(SIMPLEBLUEZ_TYPE TARGET simplebluez PROPERTY TYPE)
+if(NOT ${SIMPLEBLUEZ_TYPE} STREQUAL "STATIC_LIBRARY")
+    target_compile_definitions(simplebluez PUBLIC SIMPLEBLUEZ_SHARED)
+endif()
 
 target_link_libraries(simplebluez
     PUBLIC ${DBus1_LIBRARIES} pthread
     PRIVATE fmt::fmt-header-only)
 
 target_include_directories(simplebluez
-    PRIVATE ${SIMPLEBLUEZ_INCLUDE}
-    INTERFACE ${SIMPLEBLUEZ_INCLUDE})
+    PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../simpledbus/include>
+    PUBLIC
+        $<INSTALL_INTERFACE:include>
+)
 
 append_sanitize_options("${SIMPLEBLUEZ_SANITIZE}")
 
@@ -122,3 +134,13 @@ if(SIMPLEBLUEZ_TEST)
         COMMAND "${CMAKE_COMMAND}" -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/test/python/ ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     )
 endif()
+
+install_target(simplebluez
+    VERSION ${PROJECT_VERSION}
+    EXPORT simplebluez
+    NAMESPACE simplebluez
+    CMAKE_INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/simplebluez-config.cmake.in
+    CMAKE_OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/simplebluez-config.cmake
+)
+install(DIRECTORY include/ TYPE INCLUDE
+    FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")

--- a/simplebluez/CMakeLists.txt
+++ b/simplebluez/CMakeLists.txt
@@ -98,9 +98,9 @@ target_link_libraries(simplebluez
 target_include_directories(simplebluez
     PRIVATE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../simpledbus/include>
     PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../simpledbus/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
 )
 

--- a/simplebluez/include/simplebluez/Adapter.h
+++ b/simplebluez/include/simplebluez/Adapter.h
@@ -2,8 +2,8 @@
 
 #include <simpledbus/advanced/Proxy.h>
 
-#include <simplebluez/Export.h>
 #include <simplebluez/Device.h>
+#include <simplebluez/Export.h>
 #include <simplebluez/interfaces/Adapter1.h>
 
 #include <functional>

--- a/simplebluez/include/simplebluez/Adapter.h
+++ b/simplebluez/include/simplebluez/Adapter.h
@@ -2,6 +2,7 @@
 
 #include <simpledbus/advanced/Proxy.h>
 
+#include <simplebluez/Export.h>
 #include <simplebluez/Device.h>
 #include <simplebluez/interfaces/Adapter1.h>
 
@@ -9,7 +10,7 @@
 
 namespace SimpleBluez {
 
-class Adapter : public SimpleDBus::Proxy {
+class SIMPLEBLUEZ_EXPORT Adapter : public SimpleDBus::Proxy {
   public:
     typedef Adapter1::DiscoveryFilter DiscoveryFilter;
 

--- a/simplebluez/include/simplebluez/Agent.h
+++ b/simplebluez/include/simplebluez/Agent.h
@@ -1,11 +1,12 @@
 #pragma once
 
+#include <simplebluez/Export.h>
 #include <simplebluez/interfaces/Agent1.h>
 #include <simpledbus/advanced/Proxy.h>
 
 namespace SimpleBluez {
 
-class Agent : public SimpleDBus::Proxy {
+class SIMPLEBLUEZ_EXPORT Agent : public SimpleDBus::Proxy {
   public:
     typedef enum {
         DisplayOnly,

--- a/simplebluez/include/simplebluez/Bluez.h
+++ b/simplebluez/include/simplebluez/Bluez.h
@@ -3,9 +3,9 @@
 #include <simpledbus/advanced/Proxy.h>
 #include <simpledbus/interfaces/ObjectManager.h>
 
-#include <simplebluez/Export.h>
 #include <simplebluez/Adapter.h>
 #include <simplebluez/Agent.h>
+#include <simplebluez/Export.h>
 
 #include <vector>
 

--- a/simplebluez/include/simplebluez/Bluez.h
+++ b/simplebluez/include/simplebluez/Bluez.h
@@ -3,6 +3,7 @@
 #include <simpledbus/advanced/Proxy.h>
 #include <simpledbus/interfaces/ObjectManager.h>
 
+#include <simplebluez/Export.h>
 #include <simplebluez/Adapter.h>
 #include <simplebluez/Agent.h>
 
@@ -10,7 +11,7 @@
 
 namespace SimpleBluez {
 
-class Bluez : public SimpleDBus::Proxy {
+class SIMPLEBLUEZ_EXPORT Bluez : public SimpleDBus::Proxy {
   public:
     Bluez();
     virtual ~Bluez();

--- a/simplebluez/include/simplebluez/Characteristic.h
+++ b/simplebluez/include/simplebluez/Characteristic.h
@@ -2,6 +2,7 @@
 
 #include <simpledbus/advanced/Proxy.h>
 
+#include <simplebluez/Export.h>
 #include <simplebluez/Descriptor.h>
 #include <simplebluez/Types.h>
 #include <simplebluez/interfaces/GattCharacteristic1.h>
@@ -10,7 +11,7 @@
 
 namespace SimpleBluez {
 
-class Characteristic : public SimpleDBus::Proxy {
+class SIMPLEBLUEZ_EXPORT Characteristic : public SimpleDBus::Proxy {
   public:
     Characteristic(std::shared_ptr<SimpleDBus::Connection> conn, const std::string& bus_name, const std::string& path);
     virtual ~Characteristic();

--- a/simplebluez/include/simplebluez/Characteristic.h
+++ b/simplebluez/include/simplebluez/Characteristic.h
@@ -2,8 +2,8 @@
 
 #include <simpledbus/advanced/Proxy.h>
 
-#include <simplebluez/Export.h>
 #include <simplebluez/Descriptor.h>
+#include <simplebluez/Export.h>
 #include <simplebluez/Types.h>
 #include <simplebluez/interfaces/GattCharacteristic1.h>
 

--- a/simplebluez/include/simplebluez/Descriptor.h
+++ b/simplebluez/include/simplebluez/Descriptor.h
@@ -2,8 +2,8 @@
 
 #include <simpledbus/advanced/Proxy.h>
 
-#include <simplebluez/Types.h>
 #include <simplebluez/Export.h>
+#include <simplebluez/Types.h>
 #include <simplebluez/interfaces/GattDescriptor1.h>
 
 #include <cstdlib>

--- a/simplebluez/include/simplebluez/Descriptor.h
+++ b/simplebluez/include/simplebluez/Descriptor.h
@@ -3,13 +3,14 @@
 #include <simpledbus/advanced/Proxy.h>
 
 #include <simplebluez/Types.h>
+#include <simplebluez/Export.h>
 #include <simplebluez/interfaces/GattDescriptor1.h>
 
 #include <cstdlib>
 
 namespace SimpleBluez {
 
-class Descriptor : public SimpleDBus::Proxy {
+class SIMPLEBLUEZ_EXPORT Descriptor : public SimpleDBus::Proxy {
   public:
     Descriptor(std::shared_ptr<SimpleDBus::Connection> conn, const std::string& bus_name, const std::string& path);
     virtual ~Descriptor();

--- a/simplebluez/include/simplebluez/Device.h
+++ b/simplebluez/include/simplebluez/Device.h
@@ -2,6 +2,7 @@
 
 #include <simpledbus/advanced/Proxy.h>
 
+#include <simplebluez/Export.h>
 #include <simplebluez/Characteristic.h>
 #include <simplebluez/Service.h>
 #include <simplebluez/interfaces/Battery1.h>
@@ -9,7 +10,7 @@
 
 namespace SimpleBluez {
 
-class Device : public SimpleDBus::Proxy {
+class SIMPLEBLUEZ_EXPORT Device : public SimpleDBus::Proxy {
   public:
     Device(std::shared_ptr<SimpleDBus::Connection> conn, const std::string& bus_name, const std::string& path);
     virtual ~Device();

--- a/simplebluez/include/simplebluez/Device.h
+++ b/simplebluez/include/simplebluez/Device.h
@@ -2,8 +2,8 @@
 
 #include <simpledbus/advanced/Proxy.h>
 
-#include <simplebluez/Export.h>
 #include <simplebluez/Characteristic.h>
+#include <simplebluez/Export.h>
 #include <simplebluez/Service.h>
 #include <simplebluez/interfaces/Battery1.h>
 #include <simplebluez/interfaces/Device1.h>

--- a/simplebluez/include/simplebluez/Exceptions.h
+++ b/simplebluez/include/simplebluez/Exceptions.h
@@ -4,14 +4,15 @@
 #include <string>
 
 #include <simpledbus/base/Exceptions.h>
+#include <simplebluez/Export.h>
 
 namespace SimpleBluez {
 
 namespace Exception {
 
-class BaseException : public std::exception {};
+class SIMPLEBLUEZ_EXPORT BaseException : public std::exception {};
 
-class ServiceNotFoundException : public BaseException {
+class SIMPLEBLUEZ_EXPORT ServiceNotFoundException : public BaseException {
   public:
     ServiceNotFoundException(const std::string& service);
     const char* what() const noexcept override;
@@ -20,7 +21,7 @@ class ServiceNotFoundException : public BaseException {
     std::string _message;
 };
 
-class CharacteristicNotFoundException : public BaseException {
+class SIMPLEBLUEZ_EXPORT CharacteristicNotFoundException : public BaseException {
   public:
     CharacteristicNotFoundException(const std::string& characteristic);
     const char* what() const noexcept override;
@@ -29,7 +30,7 @@ class CharacteristicNotFoundException : public BaseException {
     std::string _message;
 };
 
-class DescriptorNotFoundException : public BaseException {
+class SIMPLEBLUEZ_EXPORT DescriptorNotFoundException : public BaseException {
   public:
     DescriptorNotFoundException(const std::string& descriptor);
     const char* what() const noexcept override;

--- a/simplebluez/include/simplebluez/Exceptions.h
+++ b/simplebluez/include/simplebluez/Exceptions.h
@@ -3,8 +3,8 @@
 #include <stdexcept>
 #include <string>
 
-#include <simpledbus/base/Exceptions.h>
 #include <simplebluez/Export.h>
+#include <simpledbus/base/Exceptions.h>
 
 namespace SimpleBluez {
 

--- a/simplebluez/include/simplebluez/Export.h
+++ b/simplebluez/include/simplebluez/Export.h
@@ -2,21 +2,21 @@
 #define SIMPLEBLUEZ_EXPORT_H
 
 #ifdef SIMPLEBLUEZ_SHARED
-#    ifdef _MSC_VER
-#        ifdef SIMPLEBLUEZ_BUILD
-#            define SIMPLEBLUEZ_EXPORT __declspec(dllexport)
-#        else
-#            define SIMPLEBLUEZ_EXPORT __declspec(dllimport)
-#        endif
-#    else
-#        ifdef SIMPLEBLUEZ_BUILD
-#            define SIMPLEBLUEZ_EXPORT __attribute__((visibility("default")))
-#        else
-#            define SIMPLEBLUEZ_EXPORT __attribute__((visibility("default")))
-#        endif
-#    endif
+#ifdef _MSC_VER
+#ifdef SIMPLEBLUEZ_BUILD
+#define SIMPLEBLUEZ_EXPORT __declspec(dllexport)
 #else
-#    define SIMPLEBLUEZ_EXPORT
+#define SIMPLEBLUEZ_EXPORT __declspec(dllimport)
+#endif
+#else
+#ifdef SIMPLEBLUEZ_BUILD
+#define SIMPLEBLUEZ_EXPORT __attribute__((visibility("default")))
+#else
+#define SIMPLEBLUEZ_EXPORT __attribute__((visibility("default")))
+#endif
+#endif
+#else
+#define SIMPLEBLUEZ_EXPORT
 #endif
 
 #endif

--- a/simplebluez/include/simplebluez/Export.h
+++ b/simplebluez/include/simplebluez/Export.h
@@ -1,0 +1,22 @@
+#ifndef SIMPLEBLUEZ_EXPORT_H
+#define SIMPLEBLUEZ_EXPORT_H
+
+#ifdef SIMPLEBLUEZ_SHARED
+#    ifdef _MSC_VER
+#        ifdef SIMPLEBLUEZ_BUILD
+#            define SIMPLEBLUEZ_EXPORT __declspec(dllexport)
+#        else
+#            define SIMPLEBLUEZ_EXPORT __declspec(dllimport)
+#        endif
+#    else
+#        ifdef SIMPLEBLUEZ_BUILD
+#            define SIMPLEBLUEZ_EXPORT __attribute__((visibility("default")))
+#        else
+#            define SIMPLEBLUEZ_EXPORT __attribute__((visibility("default")))
+#        endif
+#    endif
+#else
+#    define SIMPLEBLUEZ_EXPORT
+#endif
+
+#endif

--- a/simplebluez/include/simplebluez/Logging.h
+++ b/simplebluez/include/simplebluez/Logging.h
@@ -3,45 +3,46 @@
 #include <fmt/core.h>
 #include <cstdint>
 #include <string>
+#include <simplebluez/Export.h>
 
 namespace SimpleBluez {
 
 // clang-format off
 
-void log_fatal(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
-void log_error(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
-void log_warn(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
-void log_info(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
-void log_debug(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
-void log_verbose(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
+SIMPLEBLUEZ_EXPORT void log_fatal(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
+SIMPLEBLUEZ_EXPORT void log_error(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
+SIMPLEBLUEZ_EXPORT void log_warn(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
+SIMPLEBLUEZ_EXPORT void log_info(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
+SIMPLEBLUEZ_EXPORT void log_debug(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
+SIMPLEBLUEZ_EXPORT void log_verbose(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
 
 template <typename T, typename... Args>
-void log_fatal(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
+SIMPLEBLUEZ_EXPORT void log_fatal(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
     log_fatal(file, line, function, fmt::format(t, args...));
 }
 
 template <typename T, typename... Args>
-void log_error(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
+SIMPLEBLUEZ_EXPORT void log_error(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
     log_error(file, line, function, fmt::format(t, args...));
 }
 
 template <typename T, typename... Args>
-void log_warn(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
+SIMPLEBLUEZ_EXPORT void log_warn(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
     log_warn(file, line, function, fmt::format(t, args...));
 }
 
 template <typename T, typename... Args>
-void log_info(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
+SIMPLEBLUEZ_EXPORT void log_info(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
     log_info(file, line, function, fmt::format(t, args...));
 }
 
 template <typename T, typename... Args>
-void log_debug(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
+SIMPLEBLUEZ_EXPORT void log_debug(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
     log_debug(file, line, function, fmt::format(t, args...));
 }
 
 template <typename T, typename... Args>
-void log_verbose(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
+SIMPLEBLUEZ_EXPORT void log_verbose(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
     log_verbose(file, line, function, fmt::format(t, args...));
 }
 

--- a/simplebluez/include/simplebluez/Logging.h
+++ b/simplebluez/include/simplebluez/Logging.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <fmt/core.h>
+#include <simplebluez/Export.h>
 #include <cstdint>
 #include <string>
-#include <simplebluez/Export.h>
 
 namespace SimpleBluez {
 

--- a/simplebluez/include/simplebluez/ProxyOrg.h
+++ b/simplebluez/include/simplebluez/ProxyOrg.h
@@ -4,10 +4,11 @@
 
 #include <simplebluez/Adapter.h>
 #include <simplebluez/Agent.h>
+#include <simplebluez/Export.h>
 
 namespace SimpleBluez {
 
-class ProxyOrg : public SimpleDBus::Proxy {
+class SIMPLEBLUEZ_EXPORT ProxyOrg : public SimpleDBus::Proxy {
   public:
     ProxyOrg(std::shared_ptr<SimpleDBus::Connection> conn, const std::string& bus_name, const std::string& path);
     virtual ~ProxyOrg() = default;

--- a/simplebluez/include/simplebluez/ProxyOrgBluez.h
+++ b/simplebluez/include/simplebluez/ProxyOrgBluez.h
@@ -2,6 +2,7 @@
 
 #include <simpledbus/advanced/Proxy.h>
 
+#include <simplebluez/Export.h>
 #include <simplebluez/Adapter.h>
 #include <simplebluez/Agent.h>
 
@@ -9,7 +10,7 @@
 
 namespace SimpleBluez {
 
-class ProxyOrgBluez : public SimpleDBus::Proxy {
+class SIMPLEBLUEZ_EXPORT ProxyOrgBluez : public SimpleDBus::Proxy {
   public:
     ProxyOrgBluez(std::shared_ptr<SimpleDBus::Connection> conn, const std::string& bus_name, const std::string& path);
     virtual ~ProxyOrgBluez() = default;

--- a/simplebluez/include/simplebluez/ProxyOrgBluez.h
+++ b/simplebluez/include/simplebluez/ProxyOrgBluez.h
@@ -2,9 +2,9 @@
 
 #include <simpledbus/advanced/Proxy.h>
 
-#include <simplebluez/Export.h>
 #include <simplebluez/Adapter.h>
 #include <simplebluez/Agent.h>
+#include <simplebluez/Export.h>
 
 #include <simplebluez/interfaces/AgentManager1.h>
 

--- a/simplebluez/include/simplebluez/Service.h
+++ b/simplebluez/include/simplebluez/Service.h
@@ -2,12 +2,13 @@
 
 #include <simpledbus/advanced/Proxy.h>
 
+#include <simplebluez/Export.h>
 #include <simplebluez/Characteristic.h>
 #include <simplebluez/interfaces/GattService1.h>
 
 namespace SimpleBluez {
 
-class Service : public SimpleDBus::Proxy {
+class SIMPLEBLUEZ_EXPORT Service : public SimpleDBus::Proxy {
   public:
     Service(std::shared_ptr<SimpleDBus::Connection> conn, const std::string& bus_name, const std::string& path);
     virtual ~Service() = default;

--- a/simplebluez/include/simplebluez/Service.h
+++ b/simplebluez/include/simplebluez/Service.h
@@ -2,8 +2,8 @@
 
 #include <simpledbus/advanced/Proxy.h>
 
-#include <simplebluez/Export.h>
 #include <simplebluez/Characteristic.h>
+#include <simplebluez/Export.h>
 #include <simplebluez/interfaces/GattService1.h>
 
 namespace SimpleBluez {

--- a/simplebluez/include/simplebluez/interfaces/Adapter1.h
+++ b/simplebluez/include/simplebluez/interfaces/Adapter1.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include <simpledbus/advanced/Interface.h>
+#include <simplebluez/Export.h>
 
 #include <string>
 
 namespace SimpleBluez {
 
-class Adapter1 : public SimpleDBus::Interface {
+class SIMPLEBLUEZ_EXPORT Adapter1 : public SimpleDBus::Interface {
   public:
     typedef enum { AUTO, BREDR, LE } DiscoveryFilter;
 

--- a/simplebluez/include/simplebluez/interfaces/Adapter1.h
+++ b/simplebluez/include/simplebluez/interfaces/Adapter1.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <simpledbus/advanced/Interface.h>
 #include <simplebluez/Export.h>
+#include <simpledbus/advanced/Interface.h>
 
 #include <string>
 

--- a/simplebluez/include/simplebluez/interfaces/Agent1.h
+++ b/simplebluez/include/simplebluez/interfaces/Agent1.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <simplebluez/Export.h>
 #include <simpledbus/advanced/Interface.h>
 #include <simpledbus/external/kvn_safe_callback.hpp>
-#include <simplebluez/Export.h>
 
 #include <cstdint>
 #include <string>

--- a/simplebluez/include/simplebluez/interfaces/Agent1.h
+++ b/simplebluez/include/simplebluez/interfaces/Agent1.h
@@ -2,13 +2,14 @@
 
 #include <simpledbus/advanced/Interface.h>
 #include <simpledbus/external/kvn_safe_callback.hpp>
+#include <simplebluez/Export.h>
 
 #include <cstdint>
 #include <string>
 
 namespace SimpleBluez {
 
-class Agent1 : public SimpleDBus::Interface {
+class SIMPLEBLUEZ_EXPORT Agent1 : public SimpleDBus::Interface {
   public:
     Agent1(std::shared_ptr<SimpleDBus::Connection> conn, std::string path);
     virtual ~Agent1() = default;

--- a/simplebluez/include/simplebluez/interfaces/AgentManager1.h
+++ b/simplebluez/include/simplebluez/interfaces/AgentManager1.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <simpledbus/advanced/Interface.h>
 #include <simplebluez/Export.h>
+#include <simpledbus/advanced/Interface.h>
 
 #include <string>
 

--- a/simplebluez/include/simplebluez/interfaces/AgentManager1.h
+++ b/simplebluez/include/simplebluez/interfaces/AgentManager1.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include <simpledbus/advanced/Interface.h>
+#include <simplebluez/Export.h>
 
 #include <string>
 
 namespace SimpleBluez {
 
-class AgentManager1 : public SimpleDBus::Interface {
+class SIMPLEBLUEZ_EXPORT AgentManager1 : public SimpleDBus::Interface {
   public:
     AgentManager1(std::shared_ptr<SimpleDBus::Connection> conn, std::string path);
     virtual ~AgentManager1() = default;

--- a/simplebluez/include/simplebluez/interfaces/Battery1.h
+++ b/simplebluez/include/simplebluez/interfaces/Battery1.h
@@ -2,12 +2,13 @@
 
 #include <simpledbus/advanced/Interface.h>
 #include <simpledbus/external/kvn_safe_callback.hpp>
+#include <simplebluez/Export.h>
 
 #include <string>
 
 namespace SimpleBluez {
 
-class Battery1 : public SimpleDBus::Interface {
+class SIMPLEBLUEZ_EXPORT Battery1 : public SimpleDBus::Interface {
   public:
     Battery1(std::shared_ptr<SimpleDBus::Connection> conn, std::string path);
     virtual ~Battery1();

--- a/simplebluez/include/simplebluez/interfaces/Battery1.h
+++ b/simplebluez/include/simplebluez/interfaces/Battery1.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <simplebluez/Export.h>
 #include <simpledbus/advanced/Interface.h>
 #include <simpledbus/external/kvn_safe_callback.hpp>
-#include <simplebluez/Export.h>
 
 #include <string>
 

--- a/simplebluez/include/simplebluez/interfaces/Device1.h
+++ b/simplebluez/include/simplebluez/interfaces/Device1.h
@@ -2,12 +2,13 @@
 
 #include <simpledbus/advanced/Interface.h>
 #include <simpledbus/external/kvn_safe_callback.hpp>
+#include <simplebluez/Export.h>
 
 #include <string>
 
 namespace SimpleBluez {
 
-class Device1 : public SimpleDBus::Interface {
+class SIMPLEBLUEZ_EXPORT Device1 : public SimpleDBus::Interface {
   public:
     Device1(std::shared_ptr<SimpleDBus::Connection> conn, std::string path);
     virtual ~Device1();

--- a/simplebluez/include/simplebluez/interfaces/Device1.h
+++ b/simplebluez/include/simplebluez/interfaces/Device1.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <simplebluez/Export.h>
 #include <simpledbus/advanced/Interface.h>
 #include <simpledbus/external/kvn_safe_callback.hpp>
-#include <simplebluez/Export.h>
 
 #include <string>
 

--- a/simplebluez/include/simplebluez/interfaces/GattCharacteristic1.h
+++ b/simplebluez/include/simplebluez/interfaces/GattCharacteristic1.h
@@ -4,12 +4,13 @@
 #include <simpledbus/external/kvn_safe_callback.hpp>
 
 #include <simplebluez/Types.h>
+#include <simplebluez/Export.h>
 
 #include <string>
 
 namespace SimpleBluez {
 
-class GattCharacteristic1 : public SimpleDBus::Interface {
+class SIMPLEBLUEZ_EXPORT GattCharacteristic1 : public SimpleDBus::Interface {
   public:
     typedef enum { REQUEST = 0, COMMAND } WriteType;
 

--- a/simplebluez/include/simplebluez/interfaces/GattCharacteristic1.h
+++ b/simplebluez/include/simplebluez/interfaces/GattCharacteristic1.h
@@ -3,8 +3,8 @@
 #include <simpledbus/advanced/Interface.h>
 #include <simpledbus/external/kvn_safe_callback.hpp>
 
-#include <simplebluez/Types.h>
 #include <simplebluez/Export.h>
+#include <simplebluez/Types.h>
 
 #include <string>
 

--- a/simplebluez/include/simplebluez/interfaces/GattDescriptor1.h
+++ b/simplebluez/include/simplebluez/interfaces/GattDescriptor1.h
@@ -3,8 +3,8 @@
 #include <simpledbus/advanced/Interface.h>
 #include <simpledbus/external/kvn_safe_callback.hpp>
 
-#include <simplebluez/Types.h>
 #include <simplebluez/Export.h>
+#include <simplebluez/Types.h>
 
 #include <string>
 

--- a/simplebluez/include/simplebluez/interfaces/GattDescriptor1.h
+++ b/simplebluez/include/simplebluez/interfaces/GattDescriptor1.h
@@ -4,12 +4,13 @@
 #include <simpledbus/external/kvn_safe_callback.hpp>
 
 #include <simplebluez/Types.h>
+#include <simplebluez/Export.h>
 
 #include <string>
 
 namespace SimpleBluez {
 
-class GattDescriptor1 : public SimpleDBus::Interface {
+class SIMPLEBLUEZ_EXPORT GattDescriptor1 : public SimpleDBus::Interface {
   public:
     GattDescriptor1(std::shared_ptr<SimpleDBus::Connection> conn, std::string path);
     virtual ~GattDescriptor1();

--- a/simplebluez/include/simplebluez/interfaces/GattService1.h
+++ b/simplebluez/include/simplebluez/interfaces/GattService1.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include <simpledbus/advanced/Interface.h>
+#include <simplebluez/Export.h>
 
 #include <string>
 
 namespace SimpleBluez {
 
-class GattService1 : public SimpleDBus::Interface {
+class SIMPLEBLUEZ_EXPORT GattService1 : public SimpleDBus::Interface {
   public:
     GattService1(std::shared_ptr<SimpleDBus::Connection> conn, std::string path);
     virtual ~GattService1() = default;

--- a/simplebluez/include/simplebluez/interfaces/GattService1.h
+++ b/simplebluez/include/simplebluez/interfaces/GattService1.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <simpledbus/advanced/Interface.h>
 #include <simplebluez/Export.h>
+#include <simpledbus/advanced/Interface.h>
 
 #include <string>
 

--- a/simplebluez/simplebluez-config.cmake.in
+++ b/simplebluez/simplebluez-config.cmake.in
@@ -1,0 +1,26 @@
+#.rst:
+# simplebluez-config
+# ------------------
+# 
+# CMake package for using SimpleBluez.
+#
+# IMPORTED Targets
+# ^^^^^^^^^^^^^^^^
+# 
+# This module defines the :prop_tgt:`IMPORTED` target ``simplebluez::simplebluez``
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+
+@PACKAGE_INIT@
+
+set(TARGET_FILE "${CMAKE_CURRENT_LIST_DIR}/simplebluez-targets.cmake")
+
+include(${TARGET_FILE} OPTIONAL RESULT_VARIABLE ret)
+if(NOT ret)
+    set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)
+    set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE "${TARGET_FILE} not found.")
+    return()
+endif()
+
+# Mark the CMake package as FOUND.
+set(${CMAKE_FIND_PACKAGE_NAME}_FOUND TRUE)

--- a/simpledbus/CMakeLists.txt
+++ b/simpledbus/CMakeLists.txt
@@ -69,8 +69,8 @@ target_link_libraries(simpledbus
 target_include_directories(simpledbus
     PRIVATE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
 )
 

--- a/simpledbus/CMakeLists.txt
+++ b/simpledbus/CMakeLists.txt
@@ -12,6 +12,7 @@ project(
 include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/prelude.cmake)
 
 option(LIBFMT_VENDORIZE "Enable vendorized libfmt" ON)
+option(BUILD_SIMPLEDBUS_SHARED "Build as a shared library" OFF)
 
 find_package(fmt REQUIRED)
 find_package(DBus1 REQUIRED)
@@ -21,7 +22,9 @@ if(NOT SIMPLEDBUS_LOG_LEVEL)
     set(SIMPLEDBUS_LOG_LEVEL "FATAL")
 endif()
 
-set(SIMPLEDBUS_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+if(BUILD_SIMPLEDBUS_SHARED)
+    set(_LIBTYPE "SHARED")
+endif()
 
 set(SIMPLEDBUS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/src/advanced/Interface.cpp
@@ -36,7 +39,7 @@ set(SIMPLEDBUS_SRC
 
 # Configure the build targets
 
-add_library(simpledbus ${SIMPLEDBUS_SRC})
+add_library(simpledbus ${_LIBTYPE} ${SIMPLEDBUS_SRC})
 add_library(simpledbus::simpledbus ALIAS simpledbus)
 
 set_target_properties(
@@ -52,14 +55,24 @@ set_target_properties(
 )
 
 list(APPEND PRIVATE_COMPILE_DEFINITIONS SIMPLEDBUS_LOG_LEVEL=${SIMPLEDBUS_LOG_LEVEL})
+list(APPEND PRIVATE_COMPILE_DEFINITIONS SIMPLEDBUS_BUILD)
+
+get_property(SIMPLEDBUS_TYPE TARGET simpledbus PROPERTY TYPE)
+if(NOT ${SIMPLEDBUS_TYPE} STREQUAL "STATIC_LIBRARY")
+    target_compile_definitions(simpledbus PUBLIC SIMPLEDBUS_SHARED)
+endif()
 
 target_link_libraries(simpledbus
     PUBLIC ${DBus1_LIBRARIES}
     PRIVATE fmt::fmt-header-only)
 
 target_include_directories(simpledbus
-    PRIVATE ${SIMPLEDBUS_INCLUDE}
-    INTERFACE ${SIMPLEDBUS_INCLUDE})
+    PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    PUBLIC
+        $<INSTALL_INTERFACE:include>
+)
 
 append_sanitize_options("${SIMPLEDBUS_SANITIZE}")
 
@@ -96,3 +109,13 @@ if(SIMPLEDBUS_TEST)
         COMMAND "${CMAKE_COMMAND}" -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/test/python/ ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     )
 endif()
+
+install_target(simpledbus
+    VERSION ${PROJECT_VERSION}
+    EXPORT simpledbus
+    NAMESPACE simpledbus
+    CMAKE_INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/simpledbus-config.cmake.in
+    CMAKE_OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/simpledbus-config.cmake
+)
+install(DIRECTORY include/ TYPE INCLUDE
+    FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")

--- a/simpledbus/include/simpledbus/Export.h
+++ b/simpledbus/include/simpledbus/Export.h
@@ -2,21 +2,21 @@
 #define SIMPLEDBUS_EXPORT_H
 
 #ifdef SIMPLEDBUS_SHARED
-#    ifdef _MSC_VER
-#        ifdef SIMPLEDBUS_BUILD
-#            define SIMPLEDBUS_EXPORT __declspec(dllexport)
-#        else
-#            define SIMPLEDBUS_EXPORT __declspec(dllimport)
-#        endif
-#    else
-#        ifdef SIMPLEDBUS_BUILD
-#            define SIMPLEDBUS_EXPORT __attribute__((visibility("default")))
-#        else
-#            define SIMPLEDBUS_EXPORT __attribute__((visibility("default")))
-#        endif
-#    endif
+#ifdef _MSC_VER
+#ifdef SIMPLEDBUS_BUILD
+#define SIMPLEDBUS_EXPORT __declspec(dllexport)
 #else
-#    define SIMPLEDBUS_EXPORT
+#define SIMPLEDBUS_EXPORT __declspec(dllimport)
+#endif
+#else
+#ifdef SIMPLEDBUS_BUILD
+#define SIMPLEDBUS_EXPORT __attribute__((visibility("default")))
+#else
+#define SIMPLEDBUS_EXPORT __attribute__((visibility("default")))
+#endif
+#endif
+#else
+#define SIMPLEDBUS_EXPORT
 #endif
 
 #endif

--- a/simpledbus/include/simpledbus/Export.h
+++ b/simpledbus/include/simpledbus/Export.h
@@ -1,0 +1,22 @@
+#ifndef SIMPLEDBUS_EXPORT_H
+#define SIMPLEDBUS_EXPORT_H
+
+#ifdef SIMPLEDBUS_SHARED
+#    ifdef _MSC_VER
+#        ifdef SIMPLEDBUS_BUILD
+#            define SIMPLEDBUS_EXPORT __declspec(dllexport)
+#        else
+#            define SIMPLEDBUS_EXPORT __declspec(dllimport)
+#        endif
+#    else
+#        ifdef SIMPLEDBUS_BUILD
+#            define SIMPLEDBUS_EXPORT __attribute__((visibility("default")))
+#        else
+#            define SIMPLEDBUS_EXPORT __attribute__((visibility("default")))
+#        endif
+#    endif
+#else
+#    define SIMPLEDBUS_EXPORT
+#endif
+
+#endif

--- a/simpledbus/include/simpledbus/advanced/Interface.h
+++ b/simpledbus/include/simpledbus/advanced/Interface.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <simpledbus/Export.h>
 #include <simpledbus/base/Connection.h>
 
 #include <atomic>
@@ -10,7 +11,7 @@
 
 namespace SimpleDBus {
 
-class Interface {
+class SIMPLEDBUS_EXPORT Interface {
   public:
     Interface(std::shared_ptr<Connection> conn, const std::string& bus_name, const std::string& path,
               const std::string& interface_name);

--- a/simpledbus/include/simpledbus/advanced/Proxy.h
+++ b/simpledbus/include/simpledbus/advanced/Proxy.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <simpledbus/Export.h>
 #include <simpledbus/advanced/Interface.h>
 #include <simpledbus/external/kvn_safe_callback.hpp>
 
@@ -9,7 +10,7 @@
 
 namespace SimpleDBus {
 
-class Proxy {
+class SIMPLEDBUS_EXPORT Proxy {
   public:
     Proxy(std::shared_ptr<Connection> conn, const std::string& bus_name, const std::string& path);
     virtual ~Proxy();

--- a/simpledbus/include/simpledbus/base/Connection.h
+++ b/simpledbus/include/simpledbus/base/Connection.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <simpledbus/Export.h>
 #include <dbus/dbus.h>
+#include <simpledbus/Export.h>
 #include <mutex>
 #include "Message.h"
 

--- a/simpledbus/include/simpledbus/base/Connection.h
+++ b/simpledbus/include/simpledbus/base/Connection.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <simpledbus/Export.h>
 #include <dbus/dbus.h>
 #include <mutex>
 #include "Message.h"
@@ -8,7 +9,7 @@ namespace SimpleDBus {
 
 class Message;
 
-class Connection {
+class SIMPLEDBUS_EXPORT Connection {
   public:
     Connection(::DBusBusType dbus_bus_type);
     ~Connection();

--- a/simpledbus/include/simpledbus/base/Exceptions.h
+++ b/simpledbus/include/simpledbus/base/Exceptions.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <simpledbus/Export.h>
 #include <stdexcept>
 #include <string>
 
@@ -7,15 +8,15 @@ namespace SimpleDBus {
 
 namespace Exception {
 
-class BaseException : public std::exception {};
+class SIMPLEDBUS_EXPORT BaseException : public std::exception {};
 
-class NotInitialized : public BaseException {
+class SIMPLEDBUS_EXPORT NotInitialized : public BaseException {
   public:
     NotInitialized();
     const char* what() const noexcept override;
 };
 
-class DBusException : public BaseException {
+class SIMPLEDBUS_EXPORT DBusException : public BaseException {
   public:
     DBusException(const std::string& err_name, const std::string& err_message);
     const char* what() const noexcept override;
@@ -24,7 +25,7 @@ class DBusException : public BaseException {
     std::string _message;
 };
 
-class SendFailed : public BaseException {
+class SIMPLEDBUS_EXPORT SendFailed : public BaseException {
   public:
     SendFailed(const std::string& err_name, const std::string& err_message, const std::string& msg_str);
     const char* what() const noexcept override;
@@ -33,7 +34,7 @@ class SendFailed : public BaseException {
     std::string _message;
 };
 
-class InterfaceNotFoundException : public BaseException {
+class SIMPLEDBUS_EXPORT InterfaceNotFoundException : public BaseException {
   public:
     InterfaceNotFoundException(const std::string& path, const std::string& interface);
     const char* what() const noexcept override;
@@ -42,7 +43,7 @@ class InterfaceNotFoundException : public BaseException {
     std::string _message;
 };
 
-class PathNotFoundException : public BaseException {
+class SIMPLEDBUS_EXPORT PathNotFoundException : public BaseException {
   public:
     PathNotFoundException(const std::string& path, const std::string& subpath);
     const char* what() const noexcept override;

--- a/simpledbus/include/simpledbus/base/Holder.h
+++ b/simpledbus/include/simpledbus/base/Holder.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <simpledbus/Export.h>
 #include <any>
 #include <cstdint>
 #include <map>
@@ -10,7 +11,7 @@ namespace SimpleDBus {
 
 class Holder;
 
-class Holder {
+class SIMPLEDBUS_EXPORT Holder {
   public:
     Holder();
     ~Holder();

--- a/simpledbus/include/simpledbus/base/Logging.h
+++ b/simpledbus/include/simpledbus/base/Logging.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <simpledbus/Export.h>
 #include <fmt/core.h>
 #include <cstdint>
 #include <string>
@@ -8,40 +9,40 @@ namespace SimpleDBus {
 
 // clang-format off
 
-void log_fatal(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
-void log_error(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
-void log_warn(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
-void log_info(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
-void log_debug(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
-void log_verbose(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
+SIMPLEDBUS_EXPORT void log_fatal(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
+SIMPLEDBUS_EXPORT void log_error(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
+SIMPLEDBUS_EXPORT void log_warn(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
+SIMPLEDBUS_EXPORT void log_info(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
+SIMPLEDBUS_EXPORT void log_debug(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
+SIMPLEDBUS_EXPORT void log_verbose(const std::string& file, uint32_t line, const std::string& function, const std::string& message);
 
 template <typename T, typename... Args>
-void log_fatal(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
+SIMPLEDBUS_EXPORT void log_fatal(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
     log_fatal(file, line, function, fmt::format(t, args...));
 }
 
 template <typename T, typename... Args>
-void log_error(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
+SIMPLEDBUS_EXPORT void log_error(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
     log_error(file, line, function, fmt::format(t, args...));
 }
 
 template <typename T, typename... Args>
-void log_warn(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
+SIMPLEDBUS_EXPORT void log_warn(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
     log_warn(file, line, function, fmt::format(t, args...));
 }
 
 template <typename T, typename... Args>
-void log_info(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
+SIMPLEDBUS_EXPORT void log_info(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
     log_info(file, line, function, fmt::format(t, args...));
 }
 
 template <typename T, typename... Args>
-void log_debug(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
+SIMPLEDBUS_EXPORT void log_debug(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
     log_debug(file, line, function, fmt::format(t, args...));
 }
 
 template <typename T, typename... Args>
-void log_verbose(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
+SIMPLEDBUS_EXPORT void log_verbose(const std::string& file, uint32_t line, const std::string& function, const T& t, const Args&... args) {
     log_verbose(file, line, function, fmt::format(t, args...));
 }
 

--- a/simpledbus/include/simpledbus/base/Logging.h
+++ b/simpledbus/include/simpledbus/base/Logging.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <simpledbus/Export.h>
 #include <fmt/core.h>
+#include <simpledbus/Export.h>
 #include <cstdint>
 #include <string>
 

--- a/simpledbus/include/simpledbus/base/Message.h
+++ b/simpledbus/include/simpledbus/base/Message.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include <simpledbus/Export.h>
 #include "Connection.h"
 #include "Holder.h"
 
@@ -15,7 +16,7 @@ namespace SimpleDBus {
 class Connection;
 class Interface;
 
-class Message {
+class SIMPLEDBUS_EXPORT Message {
   public:
     typedef enum {
         INVALID = DBUS_MESSAGE_TYPE_INVALID,

--- a/simpledbus/include/simpledbus/base/Path.h
+++ b/simpledbus/include/simpledbus/base/Path.h
@@ -1,11 +1,12 @@
 #pragma once
 
+#include <simpledbus/Export.h>
 #include <string>
 #include <vector>
 
 namespace SimpleDBus {
 
-class Path {
+class SIMPLEDBUS_EXPORT Path {
   public:
     static size_t count_elements(const std::string& path);
     static std::string fetch_elements(const std::string& path, size_t count);

--- a/simpledbus/include/simpledbus/interfaces/ObjectManager.h
+++ b/simpledbus/include/simpledbus/interfaces/ObjectManager.h
@@ -1,12 +1,13 @@
 #pragma once
 
+#include <simpledbus/Export.h>
 #include <simpledbus/advanced/Interface.h>
 
 #include <functional>
 
 namespace SimpleDBus {
 
-class ObjectManager : public Interface {
+class SIMPLEDBUS_EXPORT ObjectManager : public Interface {
   public:
     ObjectManager(std::shared_ptr<Connection> conn, std::string bus_name, std::string path);
     virtual ~ObjectManager() = default;

--- a/simpledbus/simpledbus-config.cmake.in
+++ b/simpledbus/simpledbus-config.cmake.in
@@ -1,0 +1,26 @@
+#.rst:
+# simpledbus-config
+# -----------------
+# 
+# CMake package for using SimpleDBus.
+#
+# IMPORTED Targets
+# ^^^^^^^^^^^^^^^^
+# 
+# This module defines the :prop_tgt:`IMPORTED` target ``simpledbus::simpledbus``
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+
+@PACKAGE_INIT@
+
+set(TARGET_FILE "${CMAKE_CURRENT_LIST_DIR}/simpledbus-targets.cmake")
+
+include(${TARGET_FILE} OPTIONAL RESULT_VARIABLE ret)
+if(NOT ret)
+    set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)
+    set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE "${TARGET_FILE} not found.")
+    return()
+endif()
+
+# Mark the CMake package as FOUND.
+set(${CMAKE_FIND_PACKAGE_NAME}_FOUND TRUE)


### PR DESCRIPTION
This fixes the CMake build (#88), including properly exporting all symbols in shared libraries and even adding installing.

It also enables controlling which (if any) targets should be a shared library.
I particularly need this since I need to build simpleble-c as a shared library, but all the others as static.

One other thing to add: it really isn't a good idea to export e.x. SimpleDBus symbols in libsimplebluez.so (for example). SimpleBluez will still depend on SimpleDBus for it's headers, but when you list both as a dependency of a project (`target_link_libraries(myapp PRIVATE simpledbus::simpledbus simplebluez::simplebluez)`) then it will cause linking errors because the same symbols are exported twice.