### PR TITLE
Building shared libs under Windows only worked for 64 bit architecture.

### DIFF
--- a/utils/build_lib.ps1
+++ b/utils/build_lib.ps1
@@ -34,7 +34,7 @@ if ($clean) {
 New-Item -ItemType Directory -Force -Path "$BUILD_PATH" | Out-Null
 
 # Run CMake to create our build files.
-cmake -S "$SOURCE_PATH" -B "$BUILD_PATH" -DCMAKE_SYSTEM_VERSION="10.0.22000.0" -DBUILD_SHARED_LIBS=ON
+cmake -S "$SOURCE_PATH" -B "$BUILD_PATH" -DCMAKE_SYSTEM_VERSION="10.0.22000.0" -DBUILD_SHARED_LIBS=ON -A $WINDOWS_ARCH
 cmake --build "$BUILD_PATH" --config $TARGET --parallel 7
 cmake --install "$BUILD_PATH" --prefix "$INSTALL_PATH"
 
@@ -47,6 +47,6 @@ if ($examples) {
     New-Item -ItemType Directory -Force -Path "$EXAMPLE_BUILD_PATH" | Out-Null
 
     # Run CMake to create our build files.
-    cmake -S "$EXAMPLE_SOURCE_PATH" -B "$EXAMPLE_BUILD_PATH" -DCMAKE_SYSTEM_VERSION="10.0.22000.0" # -DSIMPLEBLE_LOCAL=ON
+    cmake -S "$EXAMPLE_SOURCE_PATH" -B "$EXAMPLE_BUILD_PATH" -DCMAKE_SYSTEM_VERSION="10.0.22000.0" -A $WINDOWS_ARCH # -DSIMPLEBLE_LOCAL=ON
     cmake --build "$EXAMPLE_BUILD_PATH" --config $TARGET --parallel 7
 }


### PR DESCRIPTION
Building shared lib under Windows with utils\build_lib.bat only worked for 64 bit (x64) architecture due to missing "-A $WINDOWS_ARCH" parameter on cmake command line calls in build_lib.ps1 for lib build and example build. Now "build_lib.bat -a x86" builds properly for 32 bit Windows target.