### PR TITLE
build_lib.sh does not build on Ubuntu 20.04LTS

### DIFF
--- a/utils/build_lib.sh
+++ b/utils/build_lib.sh
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bash
+#!/usr/bin/env bash
 
 # Some portions of this file where inspired from:
 #   https://medium.com/@Drew_Stokes/bash-argument-parsing-54f3b81a6a8f


### PR DESCRIPTION
build_lib.sh assumes bash is /usr/local/bin/bash but on Ubuntu it is /usr/bin/bash. Change shebang of build_lib.sh from #!/usr/local/bin/bash to #!/usr/bin/env bash, which will find bash on any Linux installation.