### PR TITLE
CMake change to support more lib versions (release/debug/minsizerel/relwithdebinfo) in the created relocatable package

### DIFF
--- a/simpleble/CMakeLists.txt
+++ b/simpleble/CMakeLists.txt
@@ -81,7 +81,11 @@ set_target_properties(simpleble PROPERTIES
     VERSION "${PROJECT_VERSION}"
     SOVERSION "${PROJECT_VERSION_MAJOR}"
     EXPORT_NAME simpleble
-    OUTPUT_NAME simpleble)
+    OUTPUT_NAME simpleble
+    RELEASE_POSTFIX ""
+    RELWITHDEBINFO_POSTFIX "-relwithdebinfo"
+    MINSIZEREL_POSTFIX "$-minsizerel"
+    DEBUG_POSTFIX "-debug")
 
 set_target_properties(simpleble-c PROPERTIES
     C_VISIBILITY_PRESET hidden
@@ -94,7 +98,11 @@ set_target_properties(simpleble-c PROPERTIES
     VERSION "${PROJECT_VERSION}"
     SOVERSION "${PROJECT_VERSION_MAJOR}"
     EXPORT_NAME simpleble-c
-    OUTPUT_NAME simpleble-c)
+    OUTPUT_NAME simpleble-c
+    RELEASE_POSTFIX ""
+    RELWITHDEBINFO_POSTFIX "-relwithdebinfo"
+    MINSIZEREL_POSTFIX "$-minsizerel"
+    DEBUG_POSTFIX "-debug")
 
 generate_export_header(
     simpleble

--- a/simpleble/CMakeLists.txt
+++ b/simpleble/CMakeLists.txt
@@ -84,7 +84,7 @@ set_target_properties(simpleble PROPERTIES
     OUTPUT_NAME simpleble
     RELEASE_POSTFIX ""
     RELWITHDEBINFO_POSTFIX "-relwithdebinfo"
-    MINSIZEREL_POSTFIX "$-minsizerel"
+    MINSIZEREL_POSTFIX "-minsizerel"
     DEBUG_POSTFIX "-debug")
 
 set_target_properties(simpleble-c PROPERTIES
@@ -101,7 +101,7 @@ set_target_properties(simpleble-c PROPERTIES
     OUTPUT_NAME simpleble-c
     RELEASE_POSTFIX ""
     RELWITHDEBINFO_POSTFIX "-relwithdebinfo"
-    MINSIZEREL_POSTFIX "$-minsizerel"
+    MINSIZEREL_POSTFIX "-minsizerel"
     DEBUG_POSTFIX "-debug")
 
 generate_export_header(


### PR DESCRIPTION
Now the relocatable package created by CMake/install can contain more lib versions (release/debug/minsizerel/relwithdebinfo) not only the latest one

Tested on win10