### PR TITLE
Change log level convention

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,7 @@ The format is based on `Keep a Changelog`_, and this project adheres to `Semanti
 **Changed**
 
 -  Debug, MinSizeRel and RelWithDebInfo targets now contain their appropriate suffix. *(Thanks kutij!)*
+-  **API CHANGE**: Log level convention changed from uppercase to capitalizing the first letter.
 -  (MacOS) More explicit exception messages.
 -  (MacOS) 16-bit UUIDs are now presented in their 128-bit form.
 

--- a/simpleble/include/simpleble/Logging.h
+++ b/simpleble/include/simpleble/Logging.h
@@ -12,16 +12,13 @@ namespace SimpleBLE {
 namespace Logging {
 
 enum Level : int {
-    NONE = 0,
-    FATAL,
-    ERROR,
-    WARN,
-    INFO,
-#pragma push_macro("DEBUG")
-#undef DEBUG
-    DEBUG,
-#pragma pop_macro("DEBUG")
-    VERBOSE,
+    None = 0,
+    Fatal,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Verbose,
 };
 
 // clang-format off
@@ -54,7 +51,7 @@ class SIMPLEBLE_EXPORT Logger {
     Logger(Logger& other) = delete;          // Remove copy constructor
     void operator=(const Logger&) = delete;  // Remove copy assignment
 
-    Level level_{Level::INFO};
+    Level level_{Level::Info};
     Callback callback_{nullptr};
     std::recursive_mutex mutex_;
 };

--- a/simpleble/src/Logging.cpp
+++ b/simpleble/src/Logging.cpp
@@ -17,25 +17,25 @@ Logger::Logger() {
                     const std::string& function, const std::string& message) {
         std::string level_string;
         switch (level) {
-            case Level::VERBOSE:
+            case Level::Verbose:
                 level_string = "VERBOSE";
                 break;
-            case Level::DEBUG:
+            case Level::Debug:
                 level_string = "DEBUG";
                 break;
-            case Level::INFO:
+            case Level::Info:
                 level_string = "INFO";
                 break;
-            case Level::WARN:
+            case Level::Warn:
                 level_string = "WARNING";
                 break;
-            case Level::ERROR:
+            case Level::Error:
                 level_string = "ERROR";
                 break;
-            case Level::FATAL:
+            case Level::Fatal:
                 level_string = "FATAL";
                 break;
-            case Level::NONE:
+            case Level::None:
                 return;
         }
 

--- a/simpleble/src/LoggingInternal.h
+++ b/simpleble/src/LoggingInternal.h
@@ -19,44 +19,44 @@
 
 #if SIMPLEBLE_LOG_LEVEL == SIMPLEDBUS_LOG_LEVEL_VERBOSE
 
-#define SIMPLEBLE_LOG_FATAL(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::FATAL, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
-#define SIMPLEBLE_LOG_ERROR(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::ERROR, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
-#define SIMPLEBLE_LOG_WARN(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::WARN, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
-#define SIMPLEBLE_LOG_INFO(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::INFO, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
-#define SIMPLEBLE_LOG_DEBUG(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::DEBUG, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_FATAL(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Fatal, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_ERROR(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Error, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_WARN(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Warn, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_INFO(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Info, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_DEBUG(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Debug, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
 #define SIMPLEBLE_LOG_VERBOSE(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::VERBOSE, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
 
 #elif SIMPLEBLE_LOG_LEVEL == SIMPLEDBUS_LOG_LEVEL_DEBUG
 
-#define SIMPLEBLE_LOG_FATAL(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::FATAL, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
-#define SIMPLEBLE_LOG_ERROR(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::ERROR, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
-#define SIMPLEBLE_LOG_WARN(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::WARN, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
-#define SIMPLEBLE_LOG_INFO(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::INFO, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
-#define SIMPLEBLE_LOG_DEBUG(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::DEBUG, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_FATAL(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Fatal, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_ERROR(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Error, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_WARN(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Warn, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_INFO(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Info, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_DEBUG(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Debug, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
 #define SIMPLEBLE_LOG_VERBOSE(msg)
 
 #elif SIMPLEBLE_LOG_LEVEL == SIMPLEDBUS_LOG_LEVEL_INFO
 
-#define SIMPLEBLE_LOG_FATAL(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::FATAL, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
-#define SIMPLEBLE_LOG_ERROR(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::ERROR, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
-#define SIMPLEBLE_LOG_WARN(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::WARN, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
-#define SIMPLEBLE_LOG_INFO(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::INFO, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_FATAL(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Fatal, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_ERROR(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Error, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_WARN(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Warn, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_INFO(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Info, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
 #define SIMPLEBLE_LOG_DEBUG(msg) 
 #define SIMPLEBLE_LOG_VERBOSE(msg)
 
 #elif SIMPLEBLE_LOG_LEVEL == SIMPLEDBUS_LOG_LEVEL_WARN
 
-#define SIMPLEBLE_LOG_FATAL(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::FATAL, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
-#define SIMPLEBLE_LOG_ERROR(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::ERROR, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
-#define SIMPLEBLE_LOG_WARN(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::WARN, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_FATAL(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Fatal, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_ERROR(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Error, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_WARN(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Warn, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
 #define SIMPLEBLE_LOG_INFO(msg) 
 #define SIMPLEBLE_LOG_DEBUG(msg) 
 #define SIMPLEBLE_LOG_VERBOSE(msg)
 
 #elif SIMPLEBLE_LOG_LEVEL == SIMPLEDBUS_LOG_LEVEL_ERROR
 
-#define SIMPLEBLE_LOG_FATAL(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::FATAL, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
-#define SIMPLEBLE_LOG_ERROR(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::ERROR, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_FATAL(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Fatal, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_ERROR(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Error, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
 #define SIMPLEBLE_LOG_WARN(msg)
 #define SIMPLEBLE_LOG_INFO(msg) 
 #define SIMPLEBLE_LOG_DEBUG(msg) 
@@ -64,7 +64,7 @@
 
 #elif SIMPLEBLE_LOG_LEVEL == SIMPLEDBUS_LOG_LEVEL_FATAL
 
-#define SIMPLEBLE_LOG_FATAL(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::FATAL, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
+#define SIMPLEBLE_LOG_FATAL(msg) SimpleBLE::Logging::Logger::get()->log(SimpleBLE::Logging::Level::Fatal, "SimpleBLE", __FILE__, __LINE__, __func__, msg)
 #define SIMPLEBLE_LOG_ERROR(msg)
 #define SIMPLEBLE_LOG_WARN(msg)
 #define SIMPLEBLE_LOG_INFO(msg) 


### PR DESCRIPTION
The capitalized convention was too prone to conflicts from other system libraries, this one should work better.