### PR TITLE
Add section for RPM-based distros

### DIFF
--- a/docs/simpleble/usage.rst
+++ b/docs/simpleble/usage.rst
@@ -20,7 +20,17 @@ General Requirements
 Linux
 -----
 
+APT-based Distros
+~~~~~~~~~~~~~~~~~
+
    - `libdbus-1-dev` (install via ``sudo apt install libdbus-1-dev``)
+
+RPM-based Distros
+~~~~~~~~~~~~~~~~~
+
+   - `dbus-devel`
+      - On Fedora, install via ``sudo dnf install dbus-devel``
+      - On CentOS, install via ``sudo yum install dbus-devel``
 
 Windows
 -------


### PR DESCRIPTION
When trying to build SimpleBLE on Fedora 36, I was running into the `dbus-1 not found` error. I found that installing `dbus-devel` solved this. I added this to the docs.