### PR TITLE
fix scan_is_active

### DIFF
--- a/simplersble/src/lib.rs
+++ b/simplersble/src/lib.rs
@@ -53,7 +53,7 @@ mod ffi {
         fn on_callback_scan_stop(self: &mut Adapter);
         fn on_callback_scan_updated(self: &mut Adapter, peripheral: &mut RustyPeripheralWrapper);
         fn on_callback_scan_found(self: &mut Adapter, peripheral: &mut RustyPeripheralWrapper);
-     
+
         type Peripheral;
 
         fn on_callback_connected(self: &mut Peripheral);
@@ -249,8 +249,8 @@ impl Adapter {
         self.internal.scan_for(timeout_ms);
     }
 
-    pub fn scan_is_active(&self) {
-        self.internal.scan_is_active();
+    pub fn scan_is_active(&self) -> bool {
+        self.internal.scan_is_active()
     }
 
     pub fn scan_get_results(&self) -> Vec<Pin<Box<Peripheral>>> {
@@ -464,7 +464,7 @@ impl Peripheral {
     fn on_callback_characteristic_updated(&self, service: &String, characteristic: &String, data: &Vec<u8>) {
         // Make a string joining the service and characteristic, then look up the callback and call it.
         let key = format!("{}{}", service, characteristic);
-        
+
         if let Some(cb) = self.on_characteristic_update_map.get(&key) {
             (cb)(data.clone());
         }


### PR DESCRIPTION
This fixes the Adapter::scan_is_active() binding to return the underlying boolean value