### PR TITLE
Give adapters a unique address on MacOS

### DIFF
--- a/simpleble/src/backends/macos/AdapterBase.mm
+++ b/simpleble/src/backends/macos/AdapterBase.mm
@@ -52,9 +52,15 @@ void* AdapterBase::underlying() const {
     return [internal underlying];
 }
 
-std::string AdapterBase::identifier() { return "Default Adapter"; }
+std::string AdapterBase::identifier() {
+    return fmt::format("Default Adapter [{}]", this->address());
+}
 
-BluetoothAddress AdapterBase::address() { return "00:00:00:00:00:00"; }
+BluetoothAddress AdapterBase::address() {
+    AdapterBaseMacOS* internal = (__bridge AdapterBaseMacOS*)opaque_internal_;
+
+    return [[internal address] UTF8String];
+}
 
 void AdapterBase::scan_start() {
     this->seen_peripherals_.clear();

--- a/simpleble/src/backends/macos/AdapterBaseMacOS.h
+++ b/simpleble/src/backends/macos/AdapterBaseMacOS.h
@@ -8,6 +8,8 @@
 
 @interface AdapterBaseMacOS : NSObject<CBCentralManagerDelegate>
 
+@property NSString *uuid;
+
 - (bool)isBluetoothEnabled;
 
 - (instancetype)init:(SimpleBLE::AdapterBase*)adapter;

--- a/simpleble/src/backends/macos/AdapterBaseMacOS.h
+++ b/simpleble/src/backends/macos/AdapterBaseMacOS.h
@@ -22,4 +22,6 @@
 
 - (bool)scanIsActive;
 
+- (NSString*)address;
+
 @end

--- a/simpleble/src/backends/macos/AdapterBaseMacOS.mm
+++ b/simpleble/src/backends/macos/AdapterBaseMacOS.mm
@@ -25,6 +25,7 @@
     self = [super init];
     if (self) {
         _adapter = adapter;
+        _uuid = [[NSUUID UUID] UUIDString];
 
         // Use a high-priority queue to ensure that events are processed immediately.
         dispatch_queue_attr_t qos = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INITIATED, -1);
@@ -54,6 +55,10 @@
 
 - (bool)scanIsActive {
     return [self.centralManager isScanning];
+}
+
+- (NSString*)address {
+    return self.uuid;
 }
 
 #pragma mark - CBCentralManagerDelegate

--- a/simplersble/src/lib.rs
+++ b/simplersble/src/lib.rs
@@ -53,7 +53,7 @@ mod ffi {
         fn on_callback_scan_stop(self: &mut Adapter);
         fn on_callback_scan_updated(self: &mut Adapter, peripheral: &mut RustyPeripheralWrapper);
         fn on_callback_scan_found(self: &mut Adapter, peripheral: &mut RustyPeripheralWrapper);
-     
+
         type Peripheral;
 
         fn on_callback_connected(self: &mut Peripheral);
@@ -249,8 +249,8 @@ impl Adapter {
         self.internal.scan_for(timeout_ms);
     }
 
-    pub fn scan_is_active(&self) {
-        self.internal.scan_is_active();
+    pub fn scan_is_active(&self) -> bool {
+        self.internal.scan_is_active()
     }
 
     pub fn scan_get_results(&self) -> Vec<Pin<Box<Peripheral>>> {
@@ -464,7 +464,7 @@ impl Peripheral {
     fn on_callback_characteristic_updated(&self, service: &String, characteristic: &String, data: &Vec<u8>) {
         // Make a string joining the service and characteristic, then look up the callback and call it.
         let key = format!("{}{}", service, characteristic);
-        
+
         if let Some(cb) = self.on_characteristic_update_map.get(&key) {
             (cb)(data.clone());
         }


### PR DESCRIPTION
Currently, the Adapter::address() function returns a MAC address with all 0s. This does not match peripheral addresses on MacOS (UUIDs), and it cannot be used e.g. to index adapters in a hash map. This commit gives adapters a UUID on MacOS and returns the UUID string in Adapter::address(). It also changes Adapter::identifier() to include the UUID string.