### PR TITLE
try to add fmt only if not already added

### DIFF
--- a/simpleble/CMakeLists.txt
+++ b/simpleble/CMakeLists.txt
@@ -18,9 +18,11 @@ include(GNUInstallDirs)
 
 option(SIMPLEBLE_PLAIN "Use plain version of SimpleBLE" OFF)
 
-option(LIBFMT_VENDORIZE "Enable vendorized libfmt" ON)
-find_package(fmt REQUIRED)
-set_target_properties(fmt PROPERTIES EXCLUDE_FROM_ALL TRUE)
+if(NOT TARGET fmt::fmt-header-only)
+    option(LIBFMT_VENDORIZE "Enable vendorized libfmt" ON)
+    find_package(fmt REQUIRED)
+    set_target_properties(fmt PROPERTIES EXCLUDE_FROM_ALL TRUE)
+endif()
 
 if(SIMPLEBLE_TEST)
     message(STATUS "Building tests requires plain version of SimpleBLE")


### PR DESCRIPTION
if fmt already has been added with add_subdirectory() call, any attempt to add again will cause errors.

If the parent project is already using fmt, and now tries to use simpleble with the [
Usage with CMake (Vendorized)](https://simpleble.readthedocs.io/en/latest/simpleble/usage.html#usage-with-cmake-vendorized) or [Usage with CMake (Local)](https://simpleble.readthedocs.io/en/latest/simpleble/usage.html#usage-with-cmake-local) method, cmake configure will show errors since all the fmt targets have already been created.

Checking if the targets are already present will prevent this.