### PR TITLE
Move bluetooth enabled check from backend to frontend

### DIFF
--- a/simpleble/src/backends/linux/AdapterBase.cpp
+++ b/simpleble/src/backends/linux/AdapterBase.cpp
@@ -42,11 +42,6 @@ BluetoothAddress AdapterBase::address() { return adapter_->address(); }
 void AdapterBase::scan_start() {
     seen_peripherals_.clear();
 
-    if (!bluetooth_enabled()) {
-        SIMPLEBLE_LOG_WARN(fmt::format("Bluetooth is not enabled."));
-        return;
-    }
-
     adapter_->set_on_device_updated([this](std::shared_ptr<SimpleBluez::Device> device) {
         if (!this->is_scanning_) {
             return;
@@ -81,11 +76,6 @@ void AdapterBase::scan_start() {
 }
 
 void AdapterBase::scan_stop() {
-    if (!bluetooth_enabled()) {
-        SIMPLEBLE_LOG_WARN(fmt::format("Bluetooth is not enabled."));
-        return;
-    }
-
     adapter_->discovery_stop();
     is_scanning_ = false;
     SAFE_CALLBACK_CALL(this->callback_on_scan_stop_);
@@ -96,11 +86,6 @@ void AdapterBase::scan_stop() {
 }
 
 void AdapterBase::scan_for(int timeout_ms) {
-    if (!bluetooth_enabled()) {
-        SIMPLEBLE_LOG_WARN(fmt::format("Bluetooth is not enabled."));
-        return;
-    }
-
     scan_start();
     std::this_thread::sleep_for(std::chrono::milliseconds(timeout_ms));
     scan_stop();

--- a/simpleble/src/backends/macos/AdapterBase.mm
+++ b/simpleble/src/backends/macos/AdapterBase.mm
@@ -65,11 +65,6 @@ BluetoothAddress AdapterBase::address() {
 void AdapterBase::scan_start() {
     this->seen_peripherals_.clear();
 
-    if (!bluetooth_enabled()) {
-        SIMPLEBLE_LOG_WARN(fmt::format("Bluetooth is not enabled."));
-        return;
-    }
-
     AdapterBaseMacOS* internal = (__bridge AdapterBaseMacOS*)opaque_internal_;
     [internal scanStart];
 
@@ -77,11 +72,6 @@ void AdapterBase::scan_start() {
 }
 
 void AdapterBase::scan_stop() {
-    if (!bluetooth_enabled()) {
-        SIMPLEBLE_LOG_WARN(fmt::format("Bluetooth is not enabled."));
-        return;
-    }
-
     AdapterBaseMacOS* internal = (__bridge AdapterBaseMacOS*)opaque_internal_;
     [internal scanStop];
 
@@ -89,11 +79,6 @@ void AdapterBase::scan_stop() {
 }
 
 void AdapterBase::scan_for(int timeout_ms) {
-    if (!bluetooth_enabled()) {
-        SIMPLEBLE_LOG_WARN(fmt::format("Bluetooth is not enabled."));
-        return;
-    }
-
     this->scan_start();
     std::this_thread::sleep_for(std::chrono::milliseconds(timeout_ms));
     this->scan_stop();

--- a/simpleble/src/backends/windows/AdapterBase.cpp
+++ b/simpleble/src/backends/windows/AdapterBase.cpp
@@ -190,11 +190,6 @@ BluetoothAddress AdapterBase::address() { return _mac_address_to_str(adapter_.Bl
 void AdapterBase::scan_start() {
     this->seen_peripherals_.clear();
 
-    if (!bluetooth_enabled()) {
-        SIMPLEBLE_LOG_WARN(fmt::format("Bluetooth is not enabled."));
-        return;
-    }
-
     scanner_.ScanningMode(Advertisement::BluetoothLEScanningMode::Active);
     scan_is_active_ = true;
     scanner_.Start();
@@ -203,11 +198,6 @@ void AdapterBase::scan_start() {
 }
 
 void AdapterBase::scan_stop() {
-    if (!bluetooth_enabled()) {
-        SIMPLEBLE_LOG_WARN(fmt::format("Bluetooth is not enabled."));
-        return;
-    }
-
     scanner_.Stop();
 
     std::unique_lock<std::mutex> lock(scan_stop_mutex_);
@@ -220,11 +210,6 @@ void AdapterBase::scan_stop() {
 }
 
 void AdapterBase::scan_for(int timeout_ms) {
-    if (!bluetooth_enabled()) {
-        SIMPLEBLE_LOG_WARN(fmt::format("Bluetooth is not enabled."));
-        return;
-    }
-
     scan_start();
     std::this_thread::sleep_for(std::chrono::milliseconds(timeout_ms));
     scan_stop();

--- a/simpleble/src/frontends/base/Adapter.cpp
+++ b/simpleble/src/frontends/base/Adapter.cpp
@@ -42,19 +42,28 @@ BluetoothAddress Adapter::address() {
 
 void Adapter::scan_start() {
     if (!initialized()) throw Exception::NotInitialized();
-
+    if (!bluetooth_enabled()) {
+        SIMPLEBLE_LOG_WARN(fmt::format("Bluetooth is not enabled."));
+        return;
+    }
     internal_->scan_start();
 }
 
 void Adapter::scan_stop() {
     if (!initialized()) throw Exception::NotInitialized();
-
+    if (!bluetooth_enabled()) {
+        SIMPLEBLE_LOG_WARN(fmt::format("Bluetooth is not enabled."));
+        return;
+    }
     internal_->scan_stop();
 }
 
 void Adapter::scan_for(int timeout_ms) {
     if (!initialized()) throw Exception::NotInitialized();
-
+    if (!bluetooth_enabled()) {
+        SIMPLEBLE_LOG_WARN(fmt::format("Bluetooth is not enabled."));
+        return;
+    }
     internal_->scan_for(timeout_ms);
 }
 


### PR DESCRIPTION
Hey @kdewald,
Is this what you meant in #144 ?
Removing the BT enabled check from the AdapterBases of linux/Mac/windows
and instead adding the code needed in the frontend?

Best,
Felix