### PR TITLE
[MacOS] Use only seen peripherals when retrieving scan results

### DIFF
--- a/simpleble/src/backends/macos/AdapterBase.mm
+++ b/simpleble/src/backends/macos/AdapterBase.mm
@@ -91,7 +91,7 @@ bool AdapterBase::scan_is_active() {
 
 std::vector<Peripheral> AdapterBase::scan_get_results() {
     std::vector<Peripheral> peripherals;
-    for (auto& [opaque_peripheral, base_peripheral] : this->peripherals_) {
+    for (auto& [opaque_peripheral, base_peripheral] : this->seen_peripherals_) {
         PeripheralBuilder peripheral_builder(base_peripheral);
         peripherals.push_back(peripheral_builder);
     }


### PR DESCRIPTION
(see title). The implication of this issue is that stale devices can be surfaced by `scan_get_results`, since `peripherals_` is never cleared.