### PR TITLE
[MacOS] Add timeout to connect

### DIFF
--- a/simpleble/src/backends/macos/PeripheralBaseMacOS.h
+++ b/simpleble/src/backends/macos/PeripheralBaseMacOS.h
@@ -19,7 +19,6 @@
 - (uint16_t)mtu;
 
 - (void)connect;
-- (void)connectWithTimeout:(NSTimeInterval)timeout;
 - (void)disconnect;
 - (bool)isConnected;
 - (std::vector<SimpleBLE::Service>)getServices;

--- a/simpleble/src/backends/macos/PeripheralBaseMacOS.h
+++ b/simpleble/src/backends/macos/PeripheralBaseMacOS.h
@@ -19,6 +19,7 @@
 - (uint16_t)mtu;
 
 - (void)connect;
+- (void)connectWithTimeout:(NSTimeInterval)timeout;
 - (void)disconnect;
 - (bool)isConnected;
 - (std::vector<SimpleBLE::Service>)getServices;


### PR DESCRIPTION
Corebluetooth docs: `Attempts to connect to a peripheral don't time out`. SimpleBLE should expose a connectWithTimeout method to handle this flow gracefully for the consumer.