### PR TITLE
fix: advertised services on BlueZ uses UUIDs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,7 @@ Don't forget to check out the following projects using SimpleBLE:
 * `GDSimpleBLE`_
 * `BrainFlow`_
 * `InsideBlue`_
+* `NodeWebBluetooth`_
 
 Contributing
 ------------
@@ -81,3 +82,4 @@ external creators, are licensed under the terms of the `MIT Licence`_.
 .. _GDSimpleBLE: https://github.com/jferdelyi/GDSimpleBLE
 .. _BrainFlow: https://github.com/brainflow-dev/brainflow
 .. _InsideBlue: https://github.com/eriklins/InsideBlue-BLE-Tool
+.. _NodeWebBluetooth: https://github.com/thegecko/webbluetooth

--- a/simpleble/src/backends/linux/PeripheralBase.cpp
+++ b/simpleble/src/backends/linux/PeripheralBase.cpp
@@ -171,9 +171,8 @@ std::vector<Service> PeripheralBase::services() {
 
 std::vector<Service> PeripheralBase::advertised_services() {
     std::vector<Service> service_list;
-    for (auto& [service_uuid, value_array] : device_->service_data()) {
-        service_list.push_back(
-            ServiceBuilder(service_uuid, ByteArray((const char*)value_array.data(), value_array.size())));
+    for (auto& service_uuid : device_->uuids()) {
+        service_list.push_back(ServiceBuilder(service_uuid));
     }
 
     return service_list;

--- a/simplebluez/include/simplebluez/Device.h
+++ b/simplebluez/include/simplebluez/Device.h
@@ -20,6 +20,7 @@ class Device : public SimpleDBus::Proxy {
 
     // ----- PROPERTIES -----
     std::vector<std::shared_ptr<Service>> services();
+    std::vector<std::string> uuids();
 
     std::string address();
     std::string address_type();

--- a/simplebluez/include/simplebluez/interfaces/Device1.h
+++ b/simplebluez/include/simplebluez/interfaces/Device1.h
@@ -26,6 +26,7 @@ class Device1 : public SimpleDBus::Interface {
     std::string AddressType();
     std::string Alias();
     std::string Name();
+    std::vector<std::string> UUIDs();
     std::map<uint16_t, std::vector<uint8_t>> ManufacturerData(bool refresh = true);
     std::map<std::string, std::vector<uint8_t>> ServiceData(bool refresh = true);
     bool Paired(bool refresh = true);

--- a/simplebluez/src/Device.cpp
+++ b/simplebluez/src/Device.cpp
@@ -73,6 +73,8 @@ int16_t Device::rssi() { return device1()->RSSI(); }
 
 int16_t Device::tx_power() { return device1()->TxPower(); }
 
+std::vector<std::string> Device::uuids() { return device1()->UUIDs(); }
+
 std::map<uint16_t, std::vector<uint8_t>> Device::manufacturer_data() { return device1()->ManufacturerData(); }
 
 std::map<std::string, std::vector<uint8_t>> Device::service_data() { return device1()->ServiceData(); }

--- a/simplebluez/src/interfaces/Device1.cpp
+++ b/simplebluez/src/interfaces/Device1.cpp
@@ -62,6 +62,17 @@ std::string Device1::Name() {
     return _properties["Name"].get_string();
 }
 
+std::vector<std::string> Device1::UUIDs() {
+    std::scoped_lock lock(_property_update_mutex);
+
+    std::vector<std::string> uuids;
+    for (SimpleDBus::Holder& uuid : _properties["UUIDs"].get_array()) {
+        uuids.push_back(uuid.get_string());
+    }
+
+    return uuids;
+}
+
 std::map<uint16_t, std::vector<uint8_t>> Device1::ManufacturerData(bool refresh) {
     if (refresh) {
         property_refresh("ManufacturerData");


### PR DESCRIPTION
This finally fixes #135. The problem was using `ServiceData` from BlueZ before connecting when it should've been `UUIDs`.
