### PR TITLE
Acquire the GIL before creating a py::bytes objects in callbacks

### DIFF
--- a/simplepyble/src/wrap_peripheral.cpp
+++ b/simplepyble/src/wrap_peripheral.cpp
@@ -162,14 +162,20 @@ void wrap_peripheral(py::module& m) {
             "notify",
             [](SimpleBLE::Peripheral& p, std::string service, std::string characteristic,
                std::function<void(py::bytes payload)> cb) {
-                p.notify(service, characteristic, [cb](SimpleBLE::ByteArray payload) { cb(py::bytes(payload)); });
+                p.notify(service, characteristic, [cb](SimpleBLE::ByteArray payload) {
+                    py::gil_scoped_acquire x;
+                    cb(py::bytes(payload));
+                });
             },
             kDocsPeripheralNotify)
         .def(
             "indicate",
             [](SimpleBLE::Peripheral& p, std::string service, std::string characteristic,
                std::function<void(py::bytes payload)> cb) {
-                p.indicate(service, characteristic, [cb](SimpleBLE::ByteArray payload) { cb(py::bytes(payload)); });
+                p.indicate(service, characteristic, [cb](SimpleBLE::ByteArray payload) {
+                    py::gil_scoped_acquire x;
+                    cb(py::bytes(payload));
+                });
             },
             kDocsPeripheralIndicate)
         .def("unsubscribe", &SimpleBLE::Peripheral::unsubscribe, kDocsPeripheralUnsubscribe)


### PR DESCRIPTION
The constructor of the py::bytes objects runs before the GIL is automatically acquired by the wrapped callback. So we have to make sure to acquire the GIL ourselves before, otherwise we'd run into corruption since PyMem_Malloc and friends are not thread safe.