### PR TITLE
Fix Python development releases, upgrade macOS runner

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -122,6 +122,9 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [tests, examples]
 
+    # Skip the job if input is empty. If not there is an error building the matrix and depending jobs will not run:
+    # 'Error when evaluating 'strategy' for job 'build'. Matrix vector 'library' does not contain any values'
+    if: ${{ inputs.libraries != '[]' && inputs.libraries != '' }}
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   tests:
-    runs-on: macos-12
+    runs-on: macos-14
 
     steps:
     - name: Clone Repository
@@ -22,7 +22,7 @@ jobs:
         $GITHUB_WORKSPACE/build_test/bin/simpleble_test
   
   examples:
-    runs-on: macos-12
+    runs-on: macos-14
 
     steps:
     - name: Clone Repository
@@ -35,7 +35,7 @@ jobs:
         cmake --build $GITHUB_WORKSPACE/build --config Release --parallel 4
 
   build:
-    runs-on: macos-12
+    runs-on: macos-14
     needs: [tests, examples]
 
     strategy:
@@ -81,7 +81,7 @@ jobs:
     uses: ./.github/workflows/ci_wheels.yml
     secrets: inherit
     with:
-      os: macos-12
+      os: macos-14
 
   rust:
     runs-on: ${{ matrix.os }}
@@ -91,7 +91,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        os: [macos-12]
+        os: [macos-14]
         arch: [arm64, x86_64]
 
     steps:

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -109,6 +109,7 @@ jobs:
   # This is not inside pre-job because 'changes' variable is set by dorny/paths-filter to ALL the filters 
   # that match, so we need to have a job with only these three filters.
   # Note that the filters are defined in a way that makes each of them depend on the previous one.
+  # If in main branch, all libraries are listed in the output even if there are no matching changes.
   libraries:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
@@ -116,7 +117,7 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      values: ${{ steps.filter.outputs.changes }}
+      values: ${{ github.ref == 'refs/heads/main' && '["simpledbus","simplebluez","simpleble"]' || steps.filter.outputs.changes }}
     steps:
       - name: Clone Repository 
         uses: actions/checkout@v4
@@ -126,8 +127,6 @@ jobs:
         with:
           filters: |
             simpledbus: &simpledbus
-              - '.github/workflows/**'
-              - '.github/actions/**'
               - 'simpledbus/**'
             simplebluez: &simplebluez
               - *simpledbus
@@ -135,6 +134,12 @@ jobs:
             simpleble: &simpleble
               - *simplebluez
               - 'simpleble/**'
+      - name: Debug Output
+        run: |
+          echo "Current branch: ${{ github.ref }}"
+          echo "Is main branch? ${{ github.ref == 'refs/heads/main' }}"
+          echo "Path filter changes: ${{ steps.filter.outputs.changes }}"
+          echo "Final libraries output: ${{ github.ref == 'refs/heads/main' && '["simpledbus","simplebluez","simpleble"]' || steps.filter.outputs.changes }}"
 
   lint:
     needs: pre_job

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - name: Clone Repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -35,6 +38,9 @@ jobs:
     steps:
       - name: Clone Repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/ci_python_publish.yml
+++ b/.github/workflows/ci_python_publish.yml
@@ -52,7 +52,9 @@ jobs:
           merge-multiple: true
       
       - name: Check Packages
-        run: twine check wheels/*.whl
+        run: |
+          pip3 install twine
+          twine check wheels/*.whl
 
       - name: Publish packages
         run: twine upload --skip-existing wheels/*.whl --verbose

--- a/.github/workflows/ci_release_cpp.yml
+++ b/.github/workflows/ci_release_cpp.yml
@@ -134,7 +134,7 @@ jobs:
           file_glob: true
 
   macos:
-    runs-on: macos-12
+    runs-on: macos-14
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci_release_python.yml
+++ b/.github/workflows/ci_release_python.yml
@@ -47,7 +47,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-12]
+        os: [ubuntu-22.04, windows-2022, macos-14]
 
     steps:
       - name: Clone repository

--- a/.github/workflows/ci_wheels.yml
+++ b/.github/workflows/ci_wheels.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - name: Clone Repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up QEMU
         if: runner.os == 'Linux'


### PR DESCRIPTION
- CI was not fetching tags when using _actions/checkout_, resulting in incorrect tagging of the development release
- Wheels were not being published because Twine was missing in _ci_python_publish.yml_
- Upgraded macOS runner from version 12 to 14. Check [this issue](https://github.com/actions/runner-images/issues/10721)
- Fix linux libraries path filter not being set for runs in main branch