### PR TITLE
Fix python source distributions builds

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -163,6 +163,7 @@ include simplepyble/src/wrap_descriptor.cpp
 include simplepyble/src/wrap_peripheral.cpp
 include simplepyble/src/wrap_service.cpp
 include simplepyble/src/wrap_types.cpp
+include external/include/external/kvn_bytearray.h
 prune .github
 prune docs
 prune examples

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ import pybind11
 import skbuild
 
 from pathlib import Path
+from setuptools.command.sdist import sdist
 
 def exclude_unnecessary_files(cmake_manifest):
     def is_necessary(name):
@@ -92,6 +93,8 @@ def get_version():
             N = get_commits_since_version_bump()
             if N > 0:
                 version_str += f".dev{N-1}"
+	# If we are not in a git repo and running from a source distribution, the VERSION
+	# file has already been updated with the corresponding dev version if necessary.
     return version_str
 
 version_str = get_version()
@@ -113,6 +116,23 @@ if args.plain:
 
 if 'PIWHEELS_BUILD' in os.environ:
     cmake_options.append("-DLIBFMT_VENDORIZE=OFF")
+
+class CustomSdist(sdist):
+    def make_release_tree(self, base_dir, files):
+
+        # First, let the parent class create the release tree
+        super().make_release_tree(base_dir, files)
+
+        version = get_version()
+        
+        if "dev" in version:
+            # Dev versions are generated dynamically.
+            # Update the VERSION file in the release tree
+            # so it matches the one published on PyPi
+            version_file = Path(base_dir) / "VERSION"
+            if version_file.exists():
+                version_file.write_text(version + "\n", encoding="utf-8")
+                print(f"Updated VERSION file in sdist to: {version}")
 
 # The information here can also be placed in setup.cfg - better separation of
 # logic and declaration, and simpler if you include description/version in a file.
@@ -153,4 +173,7 @@ skbuild.setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3 :: Only",
     ],
+    cmdclass={
+        'sdist': CustomSdist,
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import sys
 import pybind11
 import skbuild
 
+from pathlib import Path
 
 def exclude_unnecessary_files(cmake_manifest):
     def is_necessary(name):
@@ -22,6 +23,12 @@ def exclude_unnecessary_files(cmake_manifest):
 
     return list(filter(is_necessary, cmake_manifest))
 
+def is_git_repo():
+    try:
+        subprocess.check_output(['git', 'rev-parse', '--git-dir'], stderr=subprocess.DEVNULL)
+        return True
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return False
 
 def get_commit_since_hash(hash_cmd):
     result = subprocess.run(hash_cmd.split(' '),
@@ -75,13 +82,19 @@ sys.argv = [sys.argv[0]] + unknown
 root = pathlib.Path(__file__).parent.resolve()
 
 # Generate the version string
-version_str = (root / "VERSION").read_text(encoding="utf-8").strip()
+def get_version():
+    root = Path(__file__).parent
+    
+    version_str = (root / "VERSION").read_text(encoding="utf-8").strip()
+    if is_git_repo():
+        is_tagged, tag = is_current_commit_tagged()
+        if not is_tagged:
+            N = get_commits_since_version_bump()
+            if N > 0:
+                version_str += f".dev{N-1}"
+    return version_str
 
-is_tagged, tag = is_current_commit_tagged()
-if not is_tagged:
-    N = get_commits_since_version_bump()
-    if N>0:
-        version_str += f".dev{N-1}"
+version_str = get_version()
 
 # Get the long description from the README file
 long_description = (root / "simplepyble" / "README.rst").read_text(encoding="utf-8")


### PR DESCRIPTION
Problem: 
- The Python dev versioning logic assumed that `setup.py` was being executed inside a Git repository, causing an exception when building from source outside of Git
- A missing file in the `MANIFEST` caused the build to fail

Changes in this PR:
- Update `setup.py` to modify the `VERSION` file content during source distribution generation, appending the dev version if needed. This ensures consistency with the version in published wheels
- Updates `setup.py` to fall back on the `VERSION` file content if Git commands fail
- Adds the missing files to the `MANIFEST` 